### PR TITLE
Add getenv() utility function

### DIFF
--- a/lib/keyrc.k
+++ b/lib/keyrc.k
@@ -67,8 +67,8 @@ function addpostrc(f) {
 function dokeylocal() {
 
 	# KEYOUT environment variable is default output port
-	outportname = mdep("env","get","KEYOUT")
-	if ( defined(outportname) && (outportname != "") ) {
+	outportname = getenv("KEYOUT")
+	if ( outportname != "" ) {
 		out = outport(outportname)
 		if ( out >= 0 ) {
 			mapport(0,out)
@@ -308,8 +308,8 @@ function normboot() {
 
 	if ( Graphics ) {
 		# allow environment variable to control screen size
-		keysize = mdep("env","get","KEYSIZE")
-		if ( defined(keysize) && (keysize != "") ) {
+		keysize = getenv("KEYSIZE")
+		if ( keysize != "" ) {
 			eval "TMP="+keysize
 			screen("size",TMP)
 		}

--- a/lib/util2.k
+++ b/lib/util2.k
@@ -398,3 +398,11 @@ function forwardmidi(port1,port2) {
 		print("MIDI IN! N = ",n)
 	}
 }
+
+function getenv(variable) {
+	value=mdep("env","get",variable)
+	if ( !defined(value) ) {
+		value = ""
+	}
+	return(value)
+}


### PR DESCRIPTION
Add getenv) that checkes return from mdep("env","get",...) to see if its defined; if defined return string else return empty string. Update dokeylocal() and normalboot() to use getenv().