### PR TITLE
Realloc

### DIFF
--- a/src/code.c
+++ b/src/code.c
@@ -61,24 +61,12 @@ void
 pushiseg(void)
 {
 	if ( ++Niseg >= Maxiseg ) {
-		/* I'm not sure why I avoid using realloc here... */
 		int newmax = Maxiseg + ISEGINC;
 		unsigned int newsize = newmax * sizeof(Instnodep);
-		Instnodep *newIseg = (Instnodep*) kmalloc(newsize,"pushiseg");
-		Instnodep *newLastin = (Instnodep*) kmalloc(newsize,"pushiseg");
-		Instnodep *newFuture = (Instnodep*) kmalloc(newsize,"pushiseg");
-		int n;
-		for ( n=0; n<Maxiseg; n++ ) {
-			newIseg[n] = Iseg[n];
-			newLastin[n] = Lastin[n];
-			newFuture[n] = Future[n];
-		}
-		kfree(Iseg);
-		kfree(Lastin);
-		kfree(Future);
-		Iseg = newIseg;
-		Lastin = newLastin;
-		Future = newFuture;
+
+		Iseg = krealloc(Iseg, newsize, "pushiseg");
+		Lastin = krealloc(Lastin, newsize, "pushiseg");
+		Future = krealloc(Future, newsize, "pushiseg");
 		Maxiseg  = newmax;
 	}
 	clriseg();

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -319,22 +319,6 @@ sysmess(int inbyte)
 void
 biggermess(Unchar **amessage,int *aMessleng)
 {
-	Unchar *oldmess = *amessage;
-	Unchar *newmess;
-	int oldleng = *aMessleng;
-
 	*aMessleng += MESSAGESIZE;
-	newmess = (Unchar *) kmalloc( (unsigned)(sizeof(char)*(*aMessleng)), "biggermess" );
-
-	/* copy old message into larger new message */
-	if ( oldmess != NULL ) {
-		register Unchar *p = newmess;
-		register Unchar *q = oldmess;
-		register Unchar *endq = &oldmess[oldleng];
-
-		for ( ; q!=endq ; p++,q++ )
-			*p = *q;
-		kfree(oldmess);
-	}
-	*amessage = newmess;
+	*amessage = krealloc(*amessage,*aMessleng,"biggermess");
 }

--- a/src/key.h
+++ b/src/key.h
@@ -79,7 +79,7 @@ typedef struct Kobject *Kobjectp;
 // #define BIGDEBUG
 // #define DEBUGEXEC
 
-#define MDEBUG
+// #define MDEBUG
 
 /* If MDEP_MALLOC is defined, then a machine-dependent mdep.h can */
 /* provide its own macros for kmalloc and kfree. */

--- a/src/key.h
+++ b/src/key.h
@@ -79,7 +79,7 @@ typedef struct Kobject *Kobjectp;
 // #define BIGDEBUG
 // #define DEBUGEXEC
 
-// #define MDEBUG
+#define MDEBUG
 
 /* If MDEP_MALLOC is defined, then a machine-dependent mdep.h can */
 /* provide its own macros for kmalloc and kfree. */
@@ -88,9 +88,11 @@ typedef struct Kobject *Kobjectp;
 /* Note: the tag passed into kmalloc _must_ be a constant string */
 #ifdef MDEBUG
 #define kmalloc(x,tag) dbgallocate(x,tag)
+#define krealloc(x,size,tag) dbgmyrealloc(x,size,tag)
 #define kfree(x) dbgmyfree(x)
 #else
 #define kmalloc(x,tag) allocate(x,tag)
+#define krealloc(x,size,tag) myrealloc(x,size,tag)
 #define kfree(x) myfree(x)
 #endif
 

--- a/src/main.c
+++ b/src/main.c
@@ -448,17 +448,25 @@ keyerrfile(char *fmt,...)
 {
 	va_list args;
 	static FILE *f = NULL;
-
+	unsigned long milliseconds = mdep_milliclock();
+	char now[32];
 	if ( f == NULL )
 		f = fopen("key.dbg","w");
 
+	milliseconds /= 10;
+	snprintf(now, sizeof(now), "%lu.%02u: ", milliseconds / 100, (unsigned int)(milliseconds % 100));
+
 	va_start(args,fmt);
 
-	if ( f == NULL )
-		vfprintf(stderr,fmt,args);	/* last resort */
-	else {
+	if ( f == NULL ) {
+		/* last resort */
+		fputs(now, stderr);
+		vfprintf(stderr,fmt,args);
+	} else {
+		fputs(now, stdout);
 		vfprintf(stdout,fmt,args);
 		va_end(args);
+		fputs(now, f);
 		va_start(args,fmt);
 		vfprintf(f,fmt,args);
 		fflush(f);

--- a/src/mfin.c
+++ b/src/mfin.c
@@ -146,24 +146,8 @@ msgleng(void)
 static void
 msgenlarge(void)
 {
-	Unchar *newmess;
-	Unchar *oldmess = Msg1buff;
-	int oldleng = Msg1alloc;
-
 	Msg1alloc += MSGINCREMENT;
-	newmess = (Unchar *) kmalloc( (unsigned)(sizeof(char)*Msg1alloc),"msgenlarge");
-
-	/* copy old message into larger new one */
-	if ( oldmess != NULL ) {
-		register Unchar *p = newmess;
-		register Unchar *q = oldmess;
-		register Unchar *endq = &oldmess[oldleng];
-
-		for ( ; q!=endq ; p++,q++ )
-			*p = *q;
-		kfree(oldmess);
-	}
-	Msg1buff = newmess;
+	Msg1buff = krealloc(Msg1buff,Msg1alloc,"msgenlarge");
 }
 
 static void

--- a/src/phrase.c
+++ b/src/phrase.c
@@ -803,19 +803,13 @@ notetoke(INTFUNC infunc)
 
 		if ( p>=endofbuff ) {
 			/* increase size of notebuff */
-			char *r, *newbuff;
-			char *q = notebuff;
-
+			/* increase size of notebuff */
+			unsigned int oldbuffsize = buffsize;
 			buffsize += buffinc;
 			buffinc = (buffinc*3)/2;
-			newbuff = kmalloc(buffsize,"notetoke");
-			r = newbuff;
-			while ( q < p )
-				*r++ = *q++;
-			kfree(notebuff);
-			notebuff = newbuff;
+			notebuff = krealloc(notebuff, buffsize, "notetoke");
+			p = notebuff + oldbuffsize;
 			endofbuff = notebuff + buffsize;
-			p = r;
 		}
 
 		switch (state) {
@@ -1340,16 +1334,9 @@ messtont(char *s)
 			continue;
 		}
 		if ( nbytes >= bytesize ) {
-			Unchar *newbytes;
-			int oldsize = bytesize;
 			bytesize += messinc;
 			messinc = (messinc*3)/2;
-			/* should really use realloc for this */
-			newbytes = (Unchar*) kmalloc((unsigned)bytesize,"messtont");
-			while ( oldsize-- > 0 )
-				newbytes[oldsize] = bytes[oldsize];
-			kfree(bytes);
-			bytes = newbytes;
+			bytes = krealloc(bytes, bytesize, "messtont");
 		}
 		bytes[nbytes++] = 16*byte1 + h;
 		bytenum = 0;

--- a/src/task.c
+++ b/src/task.c
@@ -1887,7 +1887,7 @@ newtask(Codep cp)
 	int stksize = INITSTACKSIZE;
 	Ktaskp t = newtp(T_RUNNING);
 
-	t->stack = (Datum*) kmalloc(stksize*sizeof(Datum),"newtaskstack");
+	t->stack = alloctaskstack(stksize);
 	t->stacksize = stksize;
 	t->stackend = t->stack + stksize;
 
@@ -2265,7 +2265,7 @@ freetp(Ktaskp t)
 		}
 	}
 	if ( t->stack ) {
-		kfree(t->stack);
+		cachetaskstack(t->stack, t->stacksize);
 		t->stack = NULL;
 	}
 	t->state = T_FREE;
@@ -2407,5 +2407,67 @@ eprfunc(BYTEFUNC i)
 			keyerrfile("%s",p);
 		else
 			keyerrfile("??? %ld",(intptr_t)i);
+	}
+}
+
+/* Following is structures/functions to support caching the last
+ * CSFREELIST_SIZE freed task stacks to save on re-allocating
+ * when next task(w/stack) is created */
+struct Cachestack {
+	struct Cachestack *next;
+	void *stack;
+	unsigned int stacksize;
+};
+
+/* Number of task stacks to cache; _MUST_ be a power of two */
+#define CSFREELIST_SIZE 8
+struct Cachestack csfreelist[CSFREELIST_SIZE];
+unsigned int csfreehead = 0, csfreetail = 0;
+
+/* Return a task stack of size stksize Datum structures */
+void *
+alloctaskstack(unsigned int stksize)
+{
+	void *stack;
+	if (csfreehead - csfreetail)
+	{
+		struct Cachestack *p = &csfreelist[csfreetail++ % CSFREELIST_SIZE];
+		if (!p->stack || !p->stacksize) {
+			execerror("Huh? cache stack pool corrupted!\n");
+		}
+		stack = p->stack;
+		if (p->stacksize < stksize)
+		{
+			/* Resize stack to make it large enough */
+			stack = krealloc(p->stack, stksize * sizeof(Datum), "alloctaskstack");
+		}
+	}
+	else {
+		/* Don't have a cached stack... */
+		stack = kmalloc(stksize * sizeof(Datum), "alloctaskstack");
+	}
+	return stack;
+}
+
+/* Cache a stack for reuse when next task (that requires a stack) is created */
+void
+cachetaskstack(void *stack, unsigned int stksize)
+{
+	if (csfreehead - csfreetail < CSFREELIST_SIZE)
+	{
+		struct Cachestack *p = &csfreelist[csfreehead++ % CSFREELIST_SIZE];
+		unsigned int CUTOFFSTACKSIZE = 3*INITSTACKSIZE;
+		/* Limit cached stack to CUTOFFSTACKSIZE */
+		if (stksize > CUTOFFSTACKSIZE)
+		{
+			stack = krealloc(p->stack,CUTOFFSTACKSIZE*sizeof(Datum),"alloctaskstack");
+			stksize = CUTOFFSTACKSIZE;
+		}			
+		p->stack = stack;
+		p->stacksize = stksize;
+	}
+	else {
+		/* Already have enough cached task stacks... */
+		kfree(stack);
 	}
 }


### PR DESCRIPTION
Replace kmalloc/copy/kfree sequences with added krealloc.
Cache task stacks for reuse (saves stack allocation/free for every note played in group tool), reallocating them if too large when cached.

