### PR TITLE
Realloc2

### DIFF
--- a/src/code.c
+++ b/src/code.c
@@ -61,24 +61,12 @@ void
 pushiseg(void)
 {
 	if ( ++Niseg >= Maxiseg ) {
-		/* I'm not sure why I avoid using realloc here... */
 		int newmax = Maxiseg + ISEGINC;
 		unsigned int newsize = newmax * sizeof(Instnodep);
-		Instnodep *newIseg = (Instnodep*) kmalloc(newsize,"pushiseg");
-		Instnodep *newLastin = (Instnodep*) kmalloc(newsize,"pushiseg");
-		Instnodep *newFuture = (Instnodep*) kmalloc(newsize,"pushiseg");
-		int n;
-		for ( n=0; n<Maxiseg; n++ ) {
-			newIseg[n] = Iseg[n];
-			newLastin[n] = Lastin[n];
-			newFuture[n] = Future[n];
-		}
-		kfree(Iseg);
-		kfree(Lastin);
-		kfree(Future);
-		Iseg = newIseg;
-		Lastin = newLastin;
-		Future = newFuture;
+
+		Iseg = krealloc(Iseg, newsize, "pushiseg");
+		Lastin = krealloc(Lastin, newsize, "pushiseg");
+		Future = krealloc(Future, newsize, "pushiseg");
 		Maxiseg  = newmax;
 	}
 	clriseg();

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -319,22 +319,6 @@ sysmess(int inbyte)
 void
 biggermess(Unchar **amessage,int *aMessleng)
 {
-	Unchar *oldmess = *amessage;
-	Unchar *newmess;
-	int oldleng = *aMessleng;
-
 	*aMessleng += MESSAGESIZE;
-	newmess = (Unchar *) kmalloc( (unsigned)(sizeof(char)*(*aMessleng)), "biggermess" );
-
-	/* copy old message into larger new message */
-	if ( oldmess != NULL ) {
-		register Unchar *p = newmess;
-		register Unchar *q = oldmess;
-		register Unchar *endq = &oldmess[oldleng];
-
-		for ( ; q!=endq ; p++,q++ )
-			*p = *q;
-		kfree(oldmess);
-	}
-	*amessage = newmess;
+	*amessage = krealloc(*amessage,*aMessleng,"biggermess");
 }

--- a/src/key.h
+++ b/src/key.h
@@ -88,9 +88,11 @@ typedef struct Kobject *Kobjectp;
 /* Note: the tag passed into kmalloc _must_ be a constant string */
 #ifdef MDEBUG
 #define kmalloc(x,tag) dbgallocate(x,tag)
+#define krealloc(x,size,tag) dbgmyrealloc(x,size,tag)
 #define kfree(x) dbgmyfree(x)
 #else
 #define kmalloc(x,tag) allocate(x,tag)
+#define krealloc(x,size,tag) myrealloc(x,size,tag)
 #define kfree(x) myfree(x)
 #endif
 

--- a/src/mfin.c
+++ b/src/mfin.c
@@ -146,24 +146,8 @@ msgleng(void)
 static void
 msgenlarge(void)
 {
-	Unchar *newmess;
-	Unchar *oldmess = Msg1buff;
-	int oldleng = Msg1alloc;
-
 	Msg1alloc += MSGINCREMENT;
-	newmess = (Unchar *) kmalloc( (unsigned)(sizeof(char)*Msg1alloc),"msgenlarge");
-
-	/* copy old message into larger new one */
-	if ( oldmess != NULL ) {
-		register Unchar *p = newmess;
-		register Unchar *q = oldmess;
-		register Unchar *endq = &oldmess[oldleng];
-
-		for ( ; q!=endq ; p++,q++ )
-			*p = *q;
-		kfree(oldmess);
-	}
-	Msg1buff = newmess;
+	Msg1buff = krealloc(Msg1buff,Msg1alloc,"msgenlarge");
 }
 
 static void

--- a/src/phrase.c
+++ b/src/phrase.c
@@ -135,16 +135,10 @@ Midimessp
 savemess(Unchar* mess,int leng)
 {
 	Midimessp m;
-	register Unchar *p, *q;
-	register int n;
 
-	m = (Midimessp) kmalloc(sizeof(Midimessdata),"savemess");
+	m = (Midimessp) kmalloc(sizeof(Midimessdata)+leng-sizeof(Unchar),"savemess");
 	m->leng = leng;
-	m->bytes = (Unchar*) kmalloc((unsigned)leng,"savebytes");
-	p = m->bytes;
-	q = mess;
-	for ( n=0; n<leng; n++ )
-		*p++ = *q++;
+	memcpy(m->bytes, mess, leng);
 	return(m);
 }
 
@@ -160,7 +154,6 @@ ntfree(Noteptr n)
 		return;
         if ( typeof(n) == NT_BYTES ) {
                 m = messof(n);
-                kfree(m->bytes);
                 kfree(m);
                 /* make sure we can't try to free it again */
                 messof(n) = NULL;
@@ -174,6 +167,7 @@ Noteptr
 ntcopy(register Noteptr n)
 {
 	register Noteptr nn;
+	Midimessp m;
 	int i, nb;
 
 	nn = newnt();
@@ -185,7 +179,8 @@ ntcopy(register Noteptr n)
 	portof(nn) = portof(n);
 	switch (typeof(nn) = typeof(n)) {
 	case NT_BYTES:
-		messof(nn) = savemess(messof(n)->bytes,messof(n)->leng);
+		m = messof(n);
+		messof(nn) = savemess(m->bytes,m->leng);
 		break;
 	case NT_LE3BYTES:
 		nb = le3_nbytesof(nn) = le3_nbytesof(n);
@@ -1434,8 +1429,8 @@ ptrtobyte(register Noteptr n,register int num)
 		{
 		m = messof(n);
 
-		if ( m != NULL && m->bytes != NULL && num < m->leng )
-			return (Unchar*)(&(m->bytes[num]));
+		if ( m != NULL && num < m->leng )
+			return &m->bytes[num];
 		}
 		break;
 	}

--- a/src/phrase.c
+++ b/src/phrase.c
@@ -803,19 +803,12 @@ notetoke(INTFUNC infunc)
 
 		if ( p>=endofbuff ) {
 			/* increase size of notebuff */
-			char *r, *newbuff;
-			char *q = notebuff;
-
+			unsigned int oldbuffsize = buffsize;
 			buffsize += buffinc;
 			buffinc = (buffinc*3)/2;
-			newbuff = kmalloc(buffsize,"notetoke");
-			r = newbuff;
-			while ( q < p )
-				*r++ = *q++;
-			kfree(notebuff);
-			notebuff = newbuff;
+			notebuff = krealloc(notebuff, buffsize, "notetoke");
+			p = notebuff + oldbuffsize;
 			endofbuff = notebuff + buffsize;
-			p = r;
 		}
 
 		switch (state) {
@@ -1340,16 +1333,9 @@ messtont(char *s)
 			continue;
 		}
 		if ( nbytes >= bytesize ) {
-			Unchar *newbytes;
-			int oldsize = bytesize;
 			bytesize += messinc;
 			messinc = (messinc*3)/2;
-			/* should really use realloc for this */
-			newbytes = (Unchar*) kmalloc((unsigned)bytesize,"messtont");
-			while ( oldsize-- > 0 )
-				newbytes[oldsize] = bytes[oldsize];
-			kfree(bytes);
-			bytes = newbytes;
+			bytes = krealloc(bytes, bytesize, "messtont");
 		}
 		bytes[nbytes++] = 16*byte1 + h;
 		bytenum = 0;

--- a/src/phrase.h
+++ b/src/phrase.h
@@ -96,7 +96,7 @@
 
 typedef struct Midimessdata {
 	int leng;
-	Unchar* bytes;
+	Unchar bytes[1]; /* allocation include 'leng' bytes of data here... */
 } Midimessdata;
 
 typedef struct Notedata {


### PR DESCRIPTION
Add krealloc,  replace kmalloc/copy/kfree sequences.
Cache execution stack on task exit for reuse when creating next task (saves ~785 for prelude.mid)
Concatenate message data to Midimessdata (saves allocation per midi message) (178 for prelude.mid).
Give it a whirl...