### PR TITLE
Extend LE_3BYTE construct to hold as many bytes as size of NT_NOTE/ON…

### DIFF
--- a/src/bltin.c
+++ b/src/bltin.c
@@ -780,22 +780,22 @@ bi_midibytes(int argc)
 {
 	Phrasep p;
 	Noteptr n;
-	int nbytes = 0;
+	unsigned int nbytes = 0;
 #define SOMEBYTES 10
 	Unchar sbytes[SOMEBYTES];
 	Unchar *bytes;
 	Datum d;
-	int i, bi, bn;
+	unsigned int i, bi, bn;
 
 	if ( argc<1 )
 		execerror("usage: midibytes(byte1,byte2,byte3...)");
 
 	/* count the number of bytes that will be in the final result */
-	for ( i=0; i<argc; i++ ) {
+	for ( i=0; i<(unsigned int)argc; i++ ) {
 		d = ARG(i);
 		if ( d.type == D_PHR ) {
 			for ( n=firstnote(d.u.phr); n!=NULL; n=nextnote(n) ) {
-				if ( typeof(n) != NT_BYTES && typeof(n)!=NT_LE3BYTES )
+				if ( typeof(n) != NT_BYTES && typeof(n)!=NT_LE_NBYTES )
 					continue;
 				nbytes += ntbytesleng(n);
 			}
@@ -811,12 +811,12 @@ bi_midibytes(int argc)
 		bytes = (Unchar*) kmalloc((unsigned)nbytes*sizeof(char),"bi_midibytes");
 
 	bi = 0;
-	for ( i=0; i<argc; i++ ) {
+	for ( i=0; i<(unsigned int)argc; i++ ) {
 		d = ARG(i);
 		if ( d.type == D_PHR ) {
 			for ( n=firstnote(d.u.phr); n!=NULL; n=nextnote(n) ) {
-				int nbb;
-				if ( typeof(n) != NT_BYTES && typeof(n)!=NT_LE3BYTES )
+				unsigned int nbb;
+				if ( typeof(n) != NT_BYTES && typeof(n)!=NT_LE_NBYTES )
 					continue;
 				nbb = ntbytesleng(n);
 				for ( bn=0; bn<nbb; bn++ )
@@ -844,9 +844,9 @@ bi_midibytes(int argc)
 #ifdef NTATTRIB
 		attribof(n) = Nullstr;
 #endif
-		if ( nbytes <= 3 ) {
-			typeof(n) = NT_LE3BYTES;
-			le3_nbytesof(n) = nbytes;
+		if ( nbytes <= NOTE_DATA_NBYTES ) {
+			typeof(n) = NT_LE_NBYTES;
+			le_nbytesof(n) = nbytes;
 			for ( i=0; i<nbytes; i++ )
 				*ptrtobyte(n,i) = bytes[i];
 		}
@@ -1349,13 +1349,13 @@ void
 bi_sbbyes(int argc)
 {
 	Datum d;
-	int off;
+	unsigned int off;
 	Phrasep p;
 	Noteptr n;
 	char *s = "subbytes";
 	long origtime;
 	Unchar* origbytes;
-	int origleng, newleng;
+	unsigned int origleng, newleng;
 
 	if ( argc != 2 && argc != 3 )
 		execerror("usage: subbytes(MIDIBYTES-phrase,start,length)");
@@ -1395,10 +1395,10 @@ bi_sbbyes(int argc)
 
 	n = newnt();
 	timeof(n) = origtime;
-	if ( newleng <= 3 ) {
-		int i;
-		typeof(n) = NT_LE3BYTES;
-		le3_nbytesof(n) = (unsigned char)newleng;
+	if ( newleng <= NOTE_DATA_NBYTES ) {
+		unsigned int i;
+		typeof(n) = NT_LE_NBYTES;
+		le_nbytesof(n) = (unsigned char)newleng;
 		for ( i=0; i<newleng; i++ )
 			*ptrtobyte(n,i) = origbytes[off-1+i];
 	}

--- a/src/keyto.c
+++ b/src/keyto.c
@@ -539,7 +539,7 @@ phtrack(Phrasep p)
 
 			putdelta(timeof(n)-lasttime);
 			lasttime = timeof(n);
-			if ( typeof(n) == NT_BYTES || typeof(n) == NT_LE3BYTES) {
+			if ( typeof(n) == NT_BYTES || typeof(n) == NT_LE_NBYTES) {
 				putbytes(n);
 			}
 			else {

--- a/src/mfin.c
+++ b/src/mfin.c
@@ -507,14 +507,13 @@ k_chanpressure(int chan,int press)
 void
 threebytes(int c1,int c2,int c3)
 {
-	Unchar bytes[3];
 	Noteptr n = newnt();
 	timeof(n) = mfclicks();
-	typeof(n) = NT_BYTES;
-	bytes[0] = c1;
-	bytes[1] = c2;
-	bytes[2] = c3;
-	messof(n) = savemess(bytes,3);
+	typeof(n) = NT_LE_NBYTES;
+	le_nbytesof(n) = 3;
+	*ptrtobyte(n,0) = c1;
+	*ptrtobyte(n,1) = c2;
+	*ptrtobyte(n,2) = c3;
 	portof(n) = Defport;
 	nextnote(n) = NULL;
 	ntinsert(n,Noteq);
@@ -524,13 +523,12 @@ threebytes(int c1,int c2,int c3)
 void
 twobytes(int c1,int c2)
 {
-	Unchar bytes[2];
 	Noteptr n = newnt();
 	timeof(n) = mfclicks();
-	typeof(n) = NT_BYTES;
-	bytes[0] = c1;
-	bytes[1] = c2;
-	messof(n) = savemess(bytes,2);
+	typeof(n) = NT_LE_NBYTES;
+	le_nbytesof(n) = 2;
+	*ptrtobyte(n,0) = c1;
+	*ptrtobyte(n,1) = c2;
 	portof(n) = Defport;
 	nextnote(n) = NULL;
 	ntinsert(n,Noteq);
@@ -538,12 +536,22 @@ twobytes(int c1,int c2)
 }
 
 void
-queuemess(Unchar *mess,int leng)
+queuemess(Unchar *mess,unsigned int leng)
 {
 	Noteptr n = newnt();
+	unsigned int i;
 	timeof(n) = mfclicks();
-	typeof(n) = NT_BYTES;
-	messof(n) = savemess(mess,leng);
+	if (leng < NOTE_DATA_NBYTES) {
+		typeof(n) = NT_LE_NBYTES;
+		le_nbytesof(n) = leng;
+		for (i=0; i<leng; ++i) {
+			*ptrtobyte(n,i) = mess[i];
+		}
+	}
+	else {
+		typeof(n) = NT_BYTES;
+		messof(n) = savemess(mess,leng);
+	}
 	portof(n) = Defport;
 	nextnote(n) = NULL;
 	ntinsert(n,Noteq);

--- a/src/phrase.c
+++ b/src/phrase.c
@@ -182,8 +182,8 @@ ntcopy(register Noteptr n)
 		m = messof(n);
 		messof(nn) = savemess(m->bytes,m->leng);
 		break;
-	case NT_LE3BYTES:
-		nb = le3_nbytesof(nn) = le3_nbytesof(n);
+	case NT_LE_NBYTES:
+		nb = le_nbytesof(nn) = le_nbytesof(n);
 		for ( i=0; i<nb; i++ )
 			*ptrtobyte(nn,i) = *ptrtobyte(n,i);
 		break;
@@ -712,7 +712,7 @@ usertypeof(Noteptr nt)
 	case NT_OFF:
 		return NT_OFF;
 	case NT_BYTES:
-	case NT_LE3BYTES:
+	case NT_LE_NBYTES:
 		bp = ptrtobyte(nt,0);
 		ch1 = *bp++;
 		switch (ch1 & 0xf0) {
@@ -988,8 +988,8 @@ ntbytesleng(Noteptr n)
 {
 	if ( typeof(n) == NT_BYTES )
 		return messof(n)->leng;
-	else	/* NT_LE3BYTES */
-		return le3_nbytesof(n);
+	else	/* NT_LE_NBYTES */
+		return le_nbytesof(n);
 }
 
 /*
@@ -1282,12 +1282,13 @@ Noteptr
 messtont(char *s)
 {
 	static Unchar *bytes = NULL;
-	static int bytesize = 0;
+	static unsigned int bytesize = 0;
 	static int messinc = 64;
 	Noteptr n;
 	char c;
-	int h, i, bytenum=0, byte1=0;
-	int nbytes = 0;
+	int h, bytenum=0, byte1=0;
+	unsigned int i;
+	unsigned int nbytes = 0;
 
 	n = newnt();
 
@@ -1339,9 +1340,9 @@ messtont(char *s)
 		ntfree(n);
 		return(NULL);
 	}
-	else if ( nbytes <= 3 ) {
-		typeof(n) = NT_LE3BYTES;
-		le3_nbytesof(n) = nbytes;
+	else if ( nbytes <= NOTE_DATA_NBYTES ) {
+		typeof(n) = NT_LE_NBYTES;
+		le_nbytesof(n) = nbytes;
 		for ( i=0; i<nbytes; i++ )
 			*ptrtobyte(n,i) = bytes[i];
 	}
@@ -1421,8 +1422,8 @@ ptrtobyte(register Noteptr n,register int num)
 	register Midimessp m;
 
 	switch(typeof(n)){
-	case NT_LE3BYTES:
-		if ( num < (int)(le3_nbytesof(n)) )
+	case NT_LE_NBYTES:
+		if ( num < (int)(le_nbytesof(n)) )
 			return (Unchar*)(&(n->u.b.bytes[num]));
 		break;
 	default:	/* NT_BYTES */

--- a/src/phrase.h
+++ b/src/phrase.h
@@ -15,7 +15,7 @@
 #define NT_NOTE 2
 #define NT_ON 4
 #define NT_OFF 8
-#define NT_LE3BYTES 16
+#define NT_LE_NBYTES 16
 
 /* bits in .flags value of Notes */
 #define FLG_PICK 1
@@ -64,10 +64,10 @@
 #define durof(nt) ((nt)->u.n.duration)
 #define attribof(nt) ((nt)->attrib)
 #define flagsof(nt) ((nt)->flags)
-#define le3_nbytesof(nt) ((nt)->u.b.nbytes)
-#define gt3_nbytesof(nt) ((nt)->u.m->leng)
+#define le_nbytesof(nt) ((nt)->u.b.nbytes)
+#define gt_nbytesof(nt) ((nt)->u.m->leng)
 #define ntisnote(nt) (typeof(nt)==NT_NOTE||typeof(nt)==NT_ON||typeof(nt)==NT_OFF)
-#define ntisbytes(nt) (typeof(nt)==NT_BYTES||typeof(nt)==NT_LE3BYTES)
+#define ntisbytes(nt) (typeof(nt)==NT_BYTES||typeof(nt)==NT_LE_NBYTES)
 #define canonipitchof(p) ((p)%12)
 #define canoctave(p) (-2+(p)/12)
 #define setfirstnote(p) ((p)->p_notes)
@@ -99,23 +99,29 @@ typedef struct Midimessdata {
 	Unchar bytes[1]; /* allocation include 'leng' bytes of data here... */
 } Midimessdata;
 
+typedef struct {		/* for NT_NOTE, NT_ON, NT_OFF */
+	Unchar chan;
+	Unchar pitch;
+	Unchar vol;
+	DURATIONTYPE duration;
+} Notedatanote;
+
+#define NOTE_DATA_NBYTES ((unsigned int)(sizeof(Notedatanote)-sizeof(Unchar)))
+
+typedef struct {		/* for NT_LE_NBYTES */
+	Unchar nbytes;
+	Unchar bytes[NOTE_DATA_NBYTES];
+} Notedatanbytes;
+
 typedef struct Notedata {
 	Noteptr next;
 	long clicks;	/* # of clicks from start of phrase. */
 	union {
-		struct {		/* for NT_NOTE, NT_ON, NT_OFF */
-			Unchar chan;
-			Unchar pitch;
-			Unchar vol;
-			DURATIONTYPE duration;
-		} n;
-		struct {		/* for NT_LE3BYTES */
-			Unchar nbytes;
-			Unchar bytes[3];
-		} b;
+		Notedatanote n;		/* for NT_NOTE, NT_ON, NT_OFF */
+		Notedatanbytes b;	/* for NT_LE_NBYTES */
 		Midimessp m;		/* for NT_BYTES */
 	} u;
-	char type;	/* NT_NOTE, NT_BYTES, NT_LE3BYTES, NT_ON, NT_OFF */
+	char type;	/* NT_NOTE, NT_BYTES, NT_LE_NBYTES, NT_ON, NT_OFF */
 	Unchar port;
 	UINT16 flags;
 #ifdef NTATTRIB

--- a/src/real.c
+++ b/src/real.c
@@ -456,8 +456,8 @@ addandput(int port, int n0, int chan, int c1,int c2)
 	int c0 = n0 | chan;
 
 	timeof(n) = *Now;
-	typeof(n) = NT_LE3BYTES;
-	le3_nbytesof(n) = 3;
+	typeof(n) = NT_LE_NBYTES;
+	le_nbytesof(n) = 3;
 	*ptrtobyte(n,0) = c0;
 	*ptrtobyte(n,1) = c1;
 	*ptrtobyte(n,2) = c2;
@@ -504,7 +504,7 @@ chkinput(void)
 			noteoff(q);
 			break;
 		case NT_BYTES:
-		case NT_LE3BYTES:
+		case NT_LE_NBYTES:
 			notemess(q);
 			break;
 		}
@@ -711,7 +711,7 @@ sametime:
 			recordit = ((*Recfilter & (1<<chanof(n)))==0);
 			break;
 		case NT_BYTES:
-		case NT_LE3BYTES:
+		case NT_LE_NBYTES:
 			recordit = *Recsysex;
 			break;
 		default:
@@ -955,7 +955,7 @@ rc_mess(Unchar *mess,int indx)
 }
 
 void
-rc_messhandle(Unchar *mess,int indx, int chan)
+rc_messhandle(Unchar *mess,unsigned int indx, int chan)
 {
 	register Noteptr q;
 
@@ -971,10 +971,10 @@ rc_messhandle(Unchar *mess,int indx, int chan)
 	}
 	if ( (q=qnote(-1)) == NULL )
 		return;
-	if ( indx <= 3 ) {
-		register int i;
-		typeof(q) = NT_LE3BYTES;
-		le3_nbytesof(q) = indx;
+	if ( indx <= NOTE_DATA_NBYTES ) {
+		register unsigned int i;
+		typeof(q) = NT_LE_NBYTES;
+		le_nbytesof(q) = indx;
 		for ( i=0; i<indx; i++ ) {
 			*ptrtobyte(q,i) = mess[i];
 		}


### PR DESCRIPTION
…/OFF

Given that the LE_3BYTES note type struct is in a union with the NT_NOTE/ON/OFF struct, it makes sense to make the LE_3BYTES structure hold as many bytes to make it the same size as NT_NOTE_ON_OFF struct. Rename NT_LE3BYTES to be NT_LE_NBYTES since the bytes array is in a NT_LE_NBYTES is larger than 3.
Update three/twobytes() to create a NT_LE_NBYTES note type instead of NT_BYTES(which requires a second allocation to hold the separate Mididata).
Declare array indices affected by this change to be unsigned int.
Passes regress_stio and plays multiple midi files...