### PR TITLE
Add commandline processing for Debug variables

### DIFF
--- a/mdep/ntshare/mdep2.c
+++ b/mdep/ntshare/mdep2.c
@@ -560,11 +560,11 @@ WndProc (HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 #endif
 		return 0;
 	case MM_MIM_ERROR:
-		if ( Debugmidi!=NULL && *Debug != 0 )
+		if ( *Debug != 0 )
 			mdep_popup("WndProc got MM_MIM_ERROR!");
 		return 0;
 	case MM_MIM_LONGERROR:
-		if ( Debugmidi!=NULL && *Debug != 0 )
+		if ( *Debug != 0 )
 			mdep_popup("WndProc got MM_MIM_LONGERROR!");
 		return 0;
 #endif

--- a/src/key.h
+++ b/src/key.h
@@ -33,6 +33,11 @@
 #define NO_RETURN_ATTRIBUTE
 #endif
 
+/* ARRAY_SIZE(arry) returns num elements in statically defined array 'arry' */
+#ifndef ARRAY_SIZE
+#define ARRAY_SIZE(arry) ((unsigned int)(sizeof(arry)/sizeof((arry)[0])))
+#endif
+
 #ifdef PYTHON
 #include "Python.h"
 #endif
@@ -469,7 +474,7 @@ typedef void (*PATHFUNC)();
 /* default separator for split() on strings */
 #define DEFSPLIT " \t\n"
 
-#define ISDEBUGON (Debug!=NULL && *Debug!=0)
+#define ISDEBUGON (*Debug!=0)
 
 /* KeyKit programs get parsed and 'compiled' into lists of Inst's. */
 /* Each program segment (e.g. a function) is kept in a separate list. */
@@ -1088,7 +1093,7 @@ extern Symlongp Redrawignoretime, Resizeignoretime, Mousefnum, Warningsleep;
 extern Symlongp Millires, Milliwarn, Mousefifolimit, Minbardx, Midithrottle;
 extern Symlongp Numinst1, Numinst2, Kobjectoffset, Mousemoveevents;
 extern Symlongp Deftimeout;
-extern Symlongp Debuggesture;
+extern Symlongp Debuggesture, Debugstrsave;
 extern Symlongp Chancolors;
 extern Phrasepp Currphr, Recphr;
 extern Symstrp Keypath, Musicpath, Keyroot, Initconfig, Keypagepersistent;

--- a/src/main.c
+++ b/src/main.c
@@ -45,7 +45,6 @@ int Errors = 0;
 int Doconsole = 0;
 int Gotanint = 0;
 int Errfileit = 0;
-int Dbg = 0;
 
 char Tty[] = "tty";
 char *Infile = Tty;		/* current input file name */
@@ -1649,6 +1648,28 @@ makeparts(Symstr path)
 }
 
 int
+parsedebugargs(int argc, char **argv)
+{
+	while ( argc > 1 && argv[1][0] == '-') {
+		switch(argv[1][1])
+		{
+			case 'd':
+			case 'D':
+				if (!checkdebugarg(&argv[1][1])) {
+					eprint("Unrecognized option: %s ??\n",argv[1]);
+					return -1;
+				}
+				break;
+			default:
+				break;
+		}
+		argc--;
+		argv++;
+	}
+	return 0;
+}
+
+int
 MAIN(int argc,char **argv)
 {
 	int nerrs = 0;
@@ -1657,6 +1678,14 @@ MAIN(int argc,char **argv)
 	char *p;
 	int c;
 	int realConsolefd;
+
+	/* Must parse debug options _early_ since this initializes
+	 * Debug Symlongp variables that can be referenced before
+	 * initsyms is called. */
+	if (parsedebugargs(argc, argv)) {
+		finalexit(-1);
+		return -1;
+	}
 
 	Argv = argv;
 	Argc = argc;
@@ -1702,11 +1731,8 @@ MAIN(int argc,char **argv)
 			*Initconfig = uniqstr(p);
 			break;
 		case 'D':
-			Dbg = 1;
-			break;
 		case 'd':
-			if ( Debug )
-				(*Debug)++;
+			/* -d/-D options are handled in parsedebugargs() */
 			break;
 		case 'f':	/* for setting font, but handled by mdep_startgraphics() */
 			if ( argv[1][2]=='\0' || argv[1][3]=='\0' ) {


### PR DESCRIPTION
Add parse/checkdebugargs() to parse "-Debugxxx" values where xxx is any of the Debug variables (e.g. Debugdraw, Debugfifo, Debuggesture, Debuginst, Debugkill, Debugkill1, Debugmalloc, Debugmidi, Debugmouse, Debugoff, Debugrun, Debugwait) and if specified change the default value to one. In initsym() replaces Debug variable with same-named keykit variables initialized to the default values.  This allows specifying "-Debugmalloc" on the command line causing *Debugmalloc be non-zero before keystart() is invoked(which allows tracking keykit memory allocations before initsym is called).
Remove unused Dbg variable; make "-d" arg set *Debug to non-zero. Since all Debug variables pointers are statically initialized remove NULL checks when referencing them.
Add ARRAY_SIZE(arry) to return number of elements in statically declared arry. Add Debugstrsave (instead of using *Debugmalloc in strsave). Use *Debugmalloc in memory allocate/free/realloc instead of *Debug.