### PR TITLE
Add checkkeylib() to verify keylib.k is up to date on keykit startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ bin/savefpp_google
 doc/electromusic2005
 bin/key
 bin/lowkey
+bin/keylib
 byacc/byacc
 src/protoflp
 src/keykit.ico
@@ -44,6 +45,7 @@ src/yacc.[hc]
 src/clock.c
 src/key
 src/lowkey
+src/keylib
 src/mdep.h
 src/mdep[12].c
 src/midi.c

--- a/mdep/linux/makefile
+++ b/mdep/linux/makefile
@@ -19,10 +19,13 @@ BIN=../bin
 EXECS = $(KEY) keylib
 OBJS = yacc.o sym.o real.o code.o code2.o main.o util.o mdep1.o mfin.o \
 	phrase.o misc.o fsm.o grid.o view.o midi.o clock.o mdep2.o \
-	keyto.o regex.o task.o fifo.o kwind.o menu.o bltin.o meth.o
+	keyto.o regex.o task.o fifo.o kwind.o menu.o bltin.o meth.o \
+	chkkey.o
 SRC = real.c yacc.c code.c code2.c sym.c main.c util.c mdep1.c mfin.c \
 	phrase.c misc.c fsm.c grid.c view.c midi.c clock.c mdep2.c \
-	keyto.c regex.c task.c fifo.c kwind.c menu.c bltin.c meth.c
+	keyto.c regex.c task.c fifo.c kwind.c menu.c bltin.c meth.c \
+	chkkey.c
+
 PROFILE = -g
 CFLAGS = -Wall -Wextra -O $(INC) $(PROFILE)
 
@@ -73,7 +76,7 @@ protoproc : protoflp
 ALLDECS = d_code.h d_code2.h d_fsm.h d_grid.h d_keyto.h d_main.h d_mdep1.h \
 	d_menu.h d_mfin.h d_midi.h d_misc.h d_phrase.h d_real.h d_sym.h \
 	d_util.h d_view.h d_task.h d_fifo.h d_kwind.h d_regex.h d_bltin.h \
-	d_clock.h d_meth.h d_mdep2.h
+	d_clock.h d_meth.h d_mdep2.h d_chkkey.h
 
 # Using protoflp, Create d_xx.h from xx.c (using d_xx_h.tmp temp file):
 # 1) if d_xx.h doesn't exist

--- a/mdep/nt/makefile
+++ b/mdep/nt/makefile
@@ -9,7 +9,7 @@ WINDOWS10SDK = 10.0.18362.0
 
 VCPATHS="/libpath:\program files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.26.28801\lib\x64" \
 	"/libpath:\program files (x86)\windows kits\10\lib\$(WINDOWS10SDK)\ucrt\x64" \
-       	"/libpath:\program files (x86)\windows kits\10\lib\$(WINDOWS10SDK)\um\x64"
+	"/libpath:\program files (x86)\windows kits\10\lib\$(WINDOWS10SDK)\um\x64"
 
 
 # Reverse the order of these statements to toggle debug info
@@ -36,17 +36,17 @@ WINSOCK = wsock32.lib
 KEYOBJ = yacc.obj main.obj util.obj misc.obj phrase.obj sym.obj keyto.obj \
 	code.obj code2.obj grid.obj view.obj menu.obj task.obj fifo.obj \
 	mfin.obj real.obj mdep1.obj mdep2.obj kwind.obj fsm.obj bltin.obj \
-	meth.obj regex.obj midi.obj clock.obj rtmidi.obj rtmidi_c.obj
+	meth.obj regex.obj midi.obj clock.obj rtmidi.obj rtmidi_c.obj chkkey.obj
 
 KEYFILES = main util misc phrase sym keyto yacc \
 	code code2 grid view menu task fifo \
 	mfin real mdep1 mdep2 kwind fsm bltin meth \
-	regex midi clock
+	regex midi clock chkkey
 
 ALLDECS = d_code.h d_code2.h d_fsm.h d_grid.h d_keyto.h d_main.h d_mdep1.h \
 	d_menu.h d_mfin.h d_midi.h d_misc.h d_phrase.h d_real.h d_sym.h \
 	d_util.h d_view.h d_task.h d_fifo.h d_kwind.h d_regex.h d_bltin.h \
-	d_meth.h d_clock.h d_mdep2.h
+	d_meth.h d_clock.h d_mdep2.h d_chkkey.h
 
 # libs = $(LIBC) kernel32.lib user32.lib gdi32.lib winmm.lib comdlg32.lib $(WINSOCK) ole32.lib $(FWTRACK) setupapi.lib quartz.lib msacm32.lib oleaut32.lib advapi32.lib strmiids.lib
 #
@@ -213,6 +213,9 @@ d_menu.h : menu.c
 	.\protoflp -dd_menu.h < menu.c > tmp.c
 d_kwind.h : kwind.c
 	.\protoflp -dd_kwind.h < kwind.c > tmp.c
+d_chkkey.h : chkkey.c
+	.\protoflp -dd_chkkey.h < chkkey.c > tmp.c
+
 
 mdepback :
 	cp makefile ..\mdep\nt\makefile

--- a/mdep/ntcons/makefile
+++ b/mdep/ntcons/makefile
@@ -17,17 +17,17 @@ VC7INC=$(VC7)\include
 KEYOBJ = yacc.obj main.obj util.obj misc.obj phrase.obj sym.obj keyto.obj \
 	code.obj code2.obj grid.obj view.obj menu.obj task.obj fifo.obj \
 	mfin.obj real.obj mdep1.obj mdep2.obj kwind.obj fsm.obj bltin.obj \
-	meth.obj regex.obj midi.obj clock.obj
+	meth.obj regex.obj midi.obj clock.obj chkkey.obj
 
 KEYFILES = main util misc phrase sym keyto yacc \
 	code code2 grid view menu task fifo \
 	mfin real mdep1 mdep2 kwind fsm bltin meth \
-	regex midi clock
+	regex midi clock chkkey
 
 ALLDECS = d_code.h d_code2.h d_fsm.h d_grid.h d_keyto.h d_main.h d_mdep1.h \
 	d_menu.h d_mfin.h d_midi.h d_misc.h d_phrase.h d_real.h d_sym.h \
 	d_util.h d_view.h d_task.h d_fifo.h d_kwind.h d_regex.h d_bltin.h \
-	d_meth.h d_clock.h d_mdep2.h
+	d_meth.h d_clock.h d_mdep2.h d_chkkey.h
 
 libs =  libc.lib kernel32.lib user32.lib gdi32.lib winmm.lib comdlg32.lib
 
@@ -149,6 +149,8 @@ d_menu.h : menu.c
 	.\protoflp $(PROTO) -dd_menu.h < menu.c > tmp.c
 d_kwind.h : kwind.c
 	.\protoflp $(PROTO) -dd_kwind.h < kwind.c > tmp.c
+d_chkkey.h : chkkey.c
+	.\protoflp $(PROTO) -dd_chkkey.h < chkkey.c > tmp.c
 
 mdepback :
 	copy mdep1.c ..\mdep\ntcons\mdep1.c

--- a/mdep/ntshare/makefile
+++ b/mdep/ntshare/makefile
@@ -34,17 +34,17 @@ WINSOCK = wsock32.lib
 KEYOBJ = yacc.obj main.obj util.obj misc.obj phrase.obj sym.obj keyto.obj \
 	code.obj code2.obj grid.obj view.obj menu.obj task.obj fifo.obj \
 	mfin.obj real.obj mdep1.obj mdep2.obj kwind.obj fsm.obj bltin.obj \
-	meth.obj regex.obj midi.obj clock.obj
+	meth.obj regex.obj midi.obj clock.obj chkkey.obj
 
 KEYFILES = main util misc phrase sym keyto yacc \
 	code code2 grid view menu task fifo \
 	mfin real mdep1 mdep2 kwind fsm bltin meth \
-	regex midi clock
+	regex midi clock chkkey
 
 ALLDECS = d_code.h d_code2.h d_fsm.h d_grid.h d_keyto.h d_main.h d_mdep1.h \
 	d_menu.h d_mfin.h d_midi.h d_misc.h d_phrase.h d_real.h d_sym.h \
 	d_util.h d_view.h d_task.h d_fifo.h d_kwind.h d_regex.h d_bltin.h \
-	d_meth.h d_clock.h d_mdep2.h
+	d_meth.h d_clock.h d_mdep2.h d_chkkey.h
 
 libs =  $(LIBC).lib kernel32.lib user32.lib gdi32.lib winmm.lib comdlg32.lib $(WINSOCK)
 
@@ -204,6 +204,8 @@ d_menu.h : menu.c
 	.\protoflp $(PROTO) -dd_menu.h < menu.c > tmp.c
 d_kwind.h : kwind.c
 	.\protoflp $(PROTO) -dd_kwind.h < kwind.c > tmp.c
+d_chkkey.h : chkkey.c
+	.\protoflp $(PROTO) -dd_chkkey.h < chkkey.c > tmp.c
 
 mdepback :
 	copy makefile ..\mdep\ntshare\makefile

--- a/mdep/raspbian/makefile
+++ b/mdep/raspbian/makefile
@@ -19,10 +19,12 @@ BIN=../bin
 EXECS = $(KEY)
 OBJS = yacc.o sym.o real.o code.o code2.o main.o util.o mdep1.o mfin.o \
 	phrase.o misc.o fsm.o grid.o view.o midi.o clock.o mdep2.o \
-	keyto.o regex.o task.o fifo.o kwind.o menu.o bltin.o meth.o
+	keyto.o regex.o task.o fifo.o kwind.o menu.o bltin.o meth.o \
+	chkkey.o
 SRC = real.c yacc.c code.c code2.c sym.c main.c util.c mdep1.c mfin.c \
 	phrase.c misc.c fsm.c grid.c view.c midi.c clock.c mdep2.c \
-	keyto.c regex.c task.c fifo.c kwind.c menu.c bltin.c meth.c
+	keyto.c regex.c task.c fifo.c kwind.c menu.c bltin.c meth.c \
+	chkkey.c
 PROFILE = -g
 CFLAGS = -O $(INC) $(PROFILE)
 
@@ -69,7 +71,7 @@ protoproc : protoflp
 ALLDECS = d_code.h d_code2.h d_fsm.h d_grid.h d_keyto.h d_main.h d_mdep1.h \
 	d_menu.h d_mfin.h d_midi.h d_misc.h d_phrase.h d_real.h d_sym.h \
 	d_util.h d_view.h d_task.h d_fifo.h d_kwind.h d_regex.h d_bltin.h \
-	d_clock.h d_meth.h d_mdep2.h
+	d_clock.h d_meth.h d_mdep2.h d_chkkey.h
 
 d_regex.h : regex.c
 	./protoflp $(PROTO) -dd_regex.h < regex.c > /dev/null
@@ -119,6 +121,8 @@ d_kwind.h : kwind.c
 	./protoflp $(PROTO) -dd_kwind.h < kwind.c > /dev/null
 d_meth.h : meth.c
 	./protoflp $(PROTO) -dd_meth.h < meth.c > /dev/null
+d_chkkey.h : chkkey.c
+	./protoflp $(PROTO) -dd_chkkey.h < chkkey.c > /dev/null
 
 
 alldecs : $(ALLDECS)

--- a/mdep/stdio/makefile
+++ b/mdep/stdio/makefile
@@ -8,17 +8,17 @@ BIN=../bin
 KEYOBJ = yacc.o main.o util.o misc.o phrase.o sym.o keyto.o \
 	code.o code2.o grid.o view.o menu.o task.o fifo.o \
 	mfin.o real.o mdep1.o mdep2.o kwind.o fsm.o bltin.o \
-	meth.o regex.o midi.o clock.o
+	meth.o regex.o midi.o clock.o chkkey.o
 
 KEYFILES = main util misc phrase sym keyto yacc \
 	code code2 grid view menu task fifo \
 	mfin real mdep1 mdep2 kwind fsm bltin meth \
-	regex midi clock
+	regex midi clock chkkey
 
 ALLDECS = d_code.h d_code2.h d_fsm.h d_grid.h d_keyto.h d_main.h d_mdep1.h \
 	d_menu.h d_mfin.h d_midi.h d_misc.h d_phrase.h d_real.h d_sym.h \
 	d_util.h d_view.h d_task.h d_fifo.h d_kwind.h d_regex.h d_bltin.h \
-	d_meth.h d_clock.h d_mdep2.h
+	d_meth.h d_clock.h d_mdep2.h d_chkkey.h
 
 libs =  libc.lib kernel32.lib user32.lib gdi32.lib winmm.lib comdlg32.lib
 
@@ -112,6 +112,8 @@ d_menu.h : menu.c
 	./protoflp -s $(PROTO) -dd_menu.h < menu.c
 d_kwind.h : kwind.c
 	./protoflp -s $(PROTO) -dd_kwind.h < kwind.c
+d_chkkey.h : chkkey.c
+	./protoflp -s $(PROTO) -dd_chkkey.h < chkkey.c
 
 mdepback :
 	cp mdep1.c ../mdep/stdio/mdep1.c

--- a/src/chkkey.c
+++ b/src/chkkey.c
@@ -1,0 +1,348 @@
+
+#include "key.h"
+
+#define KEYLIB_K "keylib.k"
+
+
+/* Non-zero if error occured trying to check keylib.k */
+int checkkeylibfailed = 0;
+
+/* Duplicate string str */
+char *
+mystrdup(const char *str)
+{
+	char *p;
+	unsigned int len;
+
+	len = strlen(str);
+	p = kmalloc(len+1, "chkkey");
+	return strcpy(p, str);
+}
+
+/* Structure to track all files in a library directory(skipping keylib.k) */
+struct ftime {
+	long keylib_mtime; /* Modification time of keylib.k (or zero) */
+	struct fileandtime {
+		long mtime;
+		char *fname;
+	} *arry;
+	unsigned int dim;
+	unsigned int count;
+} ftime;
+
+/* Free the ftime structure data that holds file name and modification time */
+void
+freeftime(void)
+{
+	unsigned int i;
+	if ( ftime.arry != NULL) {
+		for (i=0; i<ftime.count; ++i)
+		{
+			kfree(ftime.arry[i].fname);
+		}
+		kfree(ftime.arry);
+	}
+	memset(&ftime, 0x00, sizeof(ftime));
+}
+
+void
+addfilentime(char *fname, long mtime)
+{
+	char *dupfname;
+	struct fileandtime *newftimearry;
+
+	if ( checkkeylibfailed ) {
+		return;
+	}
+
+	if ( ftime.count == ftime.dim )
+	{
+		ftime.dim = (3 * ftime.dim) / 2;
+		if (ftime.dim < 20) {
+			ftime.dim = 20;
+		}
+		newftimearry = realloc(ftime.arry, ftime.dim * sizeof(*ftime.arry));
+		if ( newftimearry == NULL ) {
+			eprint("Failed to allocates space for %d fileandtime structs\n", ftime.dim);
+			checkkeylibfailed = 1;
+			freeftime();
+			return;
+		}
+		ftime.arry = newftimearry;
+	}
+	dupfname = mystrdup(fname);
+	if ( dupfname = NULL )
+	{
+		eprint("Faile to duplicate '%s' string\n", fname);
+		checkkeylibfailed = 1;
+		return;
+	}
+	ftime.arry[ftime.count].mtime = mtime;
+	ftime.arry[ftime.count].fname = dupfname;
+	ftime.count++;
+}
+
+char *lsdir_prefix; /* directory prefix given mdep_lsdir() */
+
+void
+cback(char *fname, int type)
+{
+	char buf[BUFSIZ];
+	long mtime;
+	unsigned int len;
+
+	if ( checkkeylibfailed != 0 || type != 0 ) {
+		return;
+	}
+
+	len = strlen( fname );
+	if ( strcasecmp(&fname[len-2], ".k") != 0 ) {
+		return;
+	}
+	snprintf(buf, sizeof(buf), "%s%s%s", lsdir_prefix, SEPARATOR, fname);
+	mtime = mdep_filetime(buf);
+	
+	if ( strcasecmp(fname, KEYLIB_K) == 0 ) {
+		/* Skip keylib.k, but save its filetime */
+		ftime.keylib_mtime = mtime;
+	}
+	else
+	{
+		addfilentime(fname,mtime);
+	}
+}
+
+
+struct keylibklines {
+	char **arry;
+	unsigned int dim;
+	unsigned int count;
+} keylibklines;
+
+/* Add a line to the list read */
+void
+addline(const char *line)
+{
+	char **newarry;
+	char *p;
+	
+	if ( keylibklines.count == keylibklines.dim )
+	{
+		keylibklines.dim = (3 * keylibklines.dim) / 2;
+		if (keylibklines.dim < 20) {
+			keylibklines.dim = 20;
+		}
+		newarry = realloc(keylibklines.arry, keylibklines.dim * sizeof(char **));
+		if ( newarry == NULL ) {
+			eprint("Failed to allocate space for %d lines\n", keylibklines.dim);
+			exit(1);
+		}
+		keylibklines.arry = newarry;
+	}
+	/* Dup the line and add to tail of array */
+	p = mystrdup(line);
+	if ( p == NULL )
+	{
+		eprint("Failed to duplicate '%s' string\n", p);
+		exit(1);
+	}
+	keylibklines.arry[keylibklines.count++] = p;
+}
+
+void
+sortkeylibklines(void)
+{
+	unsigned int i, j;
+	for (i=0; i<keylibklines.count; ++i) {
+		for (j=i+1; j<keylibklines.count; ++j) {
+			if ( strcmp(keylibklines.arry[i], keylibklines.arry[j]) > 0 ) {
+				char *tmp;
+				tmp = keylibklines.arry[i];
+				keylibklines.arry[i] = keylibklines.arry[j];
+				keylibklines.arry[j] = tmp;
+			}
+		}
+	}
+}
+
+void
+freekeylibklines(void)
+{
+	unsigned int i;
+	for (i=0; i<keylibklines.count; ++i)
+	{
+		kfree(keylibklines.arry[i]);
+	}
+	kfree(keylibklines.arry);
+	memset(&keylibklines, 0x00, sizeof(keylibklines));
+}
+
+int
+writekeylibklines(char *keylibdir)
+{
+	char fullfname[BUFSIZ];
+	FILE *f;
+	unsigned int i;
+
+	snprintf(fullfname, sizeof(fullfname), "%s%s%s", keylibdir, SEPARATOR, KEYLIB_K);
+	if ( *Debugkeylib ) {
+		eprint("Write %u lines to '%s'\n", keylibklines.count, fullfname);
+	}
+	f = fopen(fullfname, "w");
+	if ( f == NULL ) {
+		eprint("Failed to open '%s' for writing\n", fullfname);
+		// failed = 1;
+		return -1;
+	}
+
+	for (i=0; i<keylibklines.count; ++i) {
+		fprintf(f, "%s\n", keylibklines.arry[i]);
+	}
+	fclose(f);
+	return 0;
+}
+
+int
+rebuildkeylibdir(char *keylibdir, const char *reason)
+{
+	char fullfname[BUFSIZ];
+	char buff[BUFSIZ];
+	char line[BUFSIZ];
+	unsigned int i;
+	unsigned int l;
+	char *p, *q;
+	FILE *f;
+
+	eprint("Rebuild %s%s%s since it %s\n", keylibdir, SEPARATOR, KEYLIB_K, reason);
+	for (i=0; i<ftime.count; ++i) {
+		snprintf(fullfname, sizeof(fullfname), "%s%s%s", keylibdir, SEPARATOR, ftime.arry[i].fname);
+		f = fopen(fullfname, "r");
+		if ( f == NULL ) {
+			eprint("Failed to open '%s%s%s' for reading\n", keylibdir, SEPARATOR, ftime.arry[i].fname);
+			checkkeylibfailed = 1;
+			return -1;
+		}
+		if ( *Debugkeylib ) {
+			eprint("Scanning %s...\n",fullfname);
+		}
+		while ( myfgets(buff,sizeof(buff),f) != NULL ) {
+
+			/* look for lines beginning with function or class */
+
+			if ( strncmp(buff,"function",8) == 0 ) {
+				l = 8;
+			}
+			else if ( strncmp(buff,"class",5) == 0 ) {
+				l = 5;
+			}
+			else {
+				continue;
+			}
+			if ( ! isspace(buff[l]) ) {
+				continue;
+			}
+			q = &buff[l+1];
+			while ( isspace(*q) ) {
+				q++;
+			}
+			p = q;
+			while ( *q!=0 && strchr("({ \t\n\r",*q)==NULL ) {
+				q++;
+			}
+			if ( *q != '\0' ) {
+				*q = '\0';
+			}
+			snprintf(line,sizeof(line),"#library %s %s",ftime.arry[i].fname,p);
+			addline(line);
+		}
+		fclose(f);
+	}
+	sortkeylibklines();
+	writekeylibklines(keylibdir);
+	freekeylibklines();
+	
+	return 0;
+}
+
+/* Check keylib.k in keylibdir to see if exits and if
+ * not uptodate compared to corresponding .k files then
+ * regenerate it. */
+int
+checkkeylibdir(char *keylibdir)
+{
+	const char *rebuild_reason = NULL;
+	unsigned int i;
+	
+	if ( *Debugkeylib ) {
+		eprint("'%s'\n", keylibdir);
+	}
+
+	lsdir_prefix=keylibdir;
+	mdep_lsdir(keylibdir,"*",cback);
+	if ( checkkeylibfailed ) {
+		return -1;
+	}
+	if ( ftime.count != 0L ) {
+		if ( ftime.keylib_mtime == 0L ) {
+			/* keylib.k not found - needs to be rebuilt */
+			rebuild_reason = "doesn't exist";
+		}
+		else {
+			if ( *Debugkeylib ) {
+				eprint("keylib.k modification time %ld\n", ftime.keylib_mtime);
+				eprint("Number of .k files in %s: %u\n", keylibdir, ftime.count);
+			}
+			for (i=0; i<ftime.count; ++i) {
+				if ( ftime.arry[i].mtime > ftime.keylib_mtime ) {
+					eprint("%s%s%s is newer than %s%s%s\n", keylibdir, SEPARATOR, ftime.arry[i].fname, keylibdir, SEPARATOR, KEYLIB_K);
+					/* keylib.k is out of date - needs to be rebuilt */
+					rebuild_reason = "out of date";
+				}
+			}
+		}
+
+		if ( rebuild_reason != NULL ) {
+			rebuildkeylibdir(keylibdir, rebuild_reason);
+		}
+	}
+	
+	return 0;
+}
+
+int
+checkkeylib(void)
+{
+	int ret = 0;
+	char *dupkeypath;
+	char *pathsep = PATHSEP;
+	unsigned int pathseplen;
+	char *p, *q;
+
+	checkkeylibfailed = 0;
+	
+	/* For each <dir> part of mdep_keypath() do:
+	 * 1) determine whether <dir>/keylib.k exists
+	 * 2) if so, determine if any <dir>/<file>.k (except keylib.k) is newer
+	 * 3) if 1) is false, or 2) is true then regenerate <dir>/keylib.k */
+
+	dupkeypath = mystrdup(mdep_keypath());
+	pathseplen = strlen(pathsep);
+	for (p = dupkeypath; *p; p=q+pathseplen) {
+		q = strstr(p, pathsep);
+		if ( q != NULL ) {
+			/* Break out directory component (spans from p to q) */
+			*q = '\0';
+		}
+		if ( checkkeylibdir(p) != 0 ) {
+			ret = -1;
+			goto cleanup;
+		}
+		if ( q = NULL ) {
+			break;
+		}
+	}
+  cleanup:
+	freeftime();
+	kfree(dupkeypath);
+	return ret;
+}

--- a/src/key.h
+++ b/src/key.h
@@ -1095,6 +1095,7 @@ extern Symlongp Numinst1, Numinst2, Kobjectoffset, Mousemoveevents;
 extern Symlongp Deftimeout;
 extern Symlongp Debuggesture, Debugstrsave;
 extern Symlongp Chancolors;
+extern Symlongp Debugkeylib;
 extern Phrasepp Currphr, Recphr;
 extern Symstrp Keypath, Musicpath, Keyroot, Initconfig, Keypagepersistent;
 extern Symstrp Printsep, Printend, Pathsep, Dirseparator, Devmidi, Machine;
@@ -1215,6 +1216,7 @@ Hey, mdep_statmidi is no longer used!
 #include "d_regex.h"
 #include "d_clock.h"
 #include "d_menu.h"
+#include "d_chkkey.h"
 
 /* GCC compiler only wants the no return attribute on a function's
  * prototype, _not_ its declaration. Other targets that don't define

--- a/src/main.c
+++ b/src/main.c
@@ -131,6 +131,7 @@ keystart(void)
 
 	initstrs();
 	initsyms();
+	checkkeylib(); /* Make sure <libdirs>/keylib.k is up to date */
 	pushiseg();
 	inittasks();
 	initfifos();

--- a/src/sym.c
+++ b/src/sym.c
@@ -55,6 +55,7 @@ INIT_DEBUGARG_PAIR(Debugdraw);
 INIT_DEBUGARG_PAIR(Debugfifo);
 INIT_DEBUGARG_PAIR(Debuggesture);
 INIT_DEBUGARG_PAIR(Debuginst);
+INIT_DEBUGARG_PAIR(Debugkeylib);
 INIT_DEBUGARG_PAIR(Debugkill);
 INIT_DEBUGARG_PAIR(Debugkill1);
 INIT_DEBUGARG_PAIR(Debugmalloc);
@@ -75,6 +76,7 @@ struct {
 	{ "Debugfifo", &Debugfifo, &DefaultDebugfifo },
 	{ "Debuggesture", &Debuggesture, &DefaultDebuggesture },
 	{ "Debuginst", &Debuginst, &DefaultDebuginst },
+	{ "Debugkeylib", &Debugkeylib, &DefaultDebugkeylib },
 	{ "Debugkill", &Debugkill, &DefaultDebugkill },
 	{ "Debugkill1", &Debugkill1, &DefaultDebugkill1 },
 	{ "Debugmalloc", &Debugmalloc, &DefaultDebugmalloc },


### PR DESCRIPTION
Add chkkey.c that contains checkkeylib() which is called in keystart to make sure keylib.k in each directory specified in keypath is up to date; if not, regenerate.
Add Debugkeylib variable to control verbose output from chekkeylib().

Verifies by removing lib/keylib.k and starting keykit.