### PR TITLE
Fix keytest.sh

### DIFF
--- a/mdep/linux/mdep1.c
+++ b/mdep/linux/mdep1.c
@@ -116,7 +116,7 @@ mdep_lsdir(char *dir, char *exp, void (*callback)(char*,int))
 	FILE *f;
 	struct stat sb;
 	int dleng = strlen(dir);
-	char *sep = "/";
+	char *sep = SEPARATOR;
 
 	/* If dir ends in "/", don't add an additional "/" */
 	if ( dleng > 0 && dir[dleng-1] == '/' )
@@ -134,15 +134,16 @@ mdep_lsdir(char *dir, char *exp, void (*callback)(char*,int))
 			*p = '\0';
 		if ( stat(buff,&sb) < 0 )
 			continue;
-		/* Strip off original directory and prefix */
+
+		/* Strip off original directory and separator(if there) */
 		len = strlen(dir);
 		p = buff;
 		if ( strncmp(p, dir, len) == 0 ) {
 			p += len;
-		}
-		len = strlen(sep);
-		if ( strncmp(p, sep, len) == 0 ) {
-			p += len;
+			len = strlen(sep);
+			if ( strncmp(p, sep, len) == 0 ) {
+				p += len;
+			}
 		}
 		callback(p,S_ISDIR(sb.st_mode)?1:0);
 	}

--- a/mdep/stdio/makefile
+++ b/mdep/stdio/makefile
@@ -1,5 +1,5 @@
 CC = gcc
-CFLAGS = -Wall -Wextra -O
+CFLAGS = -Wall -Wextra -O -g
 STATIC = -static
 
 PROTO = -p

--- a/src/chkkey.c
+++ b/src/chkkey.c
@@ -204,7 +204,10 @@ rebuildkeylibdir(char *keylibdir, const char *reason)
 	char *p, *q;
 	FILE *f;
 
-	eprint("Rebuild %s%s%s since it %s\n", keylibdir, SEPARATOR, KEYLIB_K, reason);
+	if ( *Debugkeylib ) {
+		eprint("Rebuild %s%s%s since it %s\n", keylibdir, SEPARATOR, KEYLIB_K, reason);
+	}
+
 	for (i=0; i<ftime.count; ++i) {
 		snprintf(fullfname, sizeof(fullfname), "%s%s%s", keylibdir, SEPARATOR, ftime.arry[i].fname);
 		f = fopen(fullfname, "r");
@@ -291,6 +294,7 @@ checkkeylibdir(char *keylibdir)
 			rebuildkeylibdir(keylibdir, rebuild_reason);
 		}
 	}
+	freeftime();
 	
 	return 0;
 }

--- a/tests/keytest.sh
+++ b/tests/keytest.sh
@@ -1,40 +1,40 @@
 echo Running ack test ...
-../bin/lowkey ack.k > ack.out
+KEYPATH=../lib ../bin/lowkey ack.k > ack.out
 diff ack.out ack.sav
 
 echo Running attrib test ...
-../bin/lowkey attrib.k > attrib.out
+KEYPATH=../lib ../bin/lowkey attrib.k > attrib.out
 diff attrib.out attrib.sav
 
 echo Running bigtest test ...
-../bin/lowkey bigtest.k > bigtest.out
+KEYPATH=../lib ../bin/lowkey bigtest.k > bigtest.out
 diff bigtest.out bigtest.sav
 
 echo Running control test ...
-../bin/lowkey control.k > control.out
+KEYPATH=../lib ../bin/lowkey control.k > control.out
 diff control.out control.sav
 
 echo Running dot test ...
-../bin/lowkey dot.k > dot.out
+KEYPATH=../lib ../bin/lowkey dot.k > dot.out
 diff dot.out dot.sav
 
 echo Running fork test ...
-../bin/lowkey fork.k > fork.out
+KEYPATH=../lib ../bin/lowkey fork.k > fork.out
 diff fork.out fork.sav
 
 echo Running more test ...
-../bin/lowkey more.k > more.out
+KEYPATH=../lib ../bin/lowkey more.k > more.out
 diff more.out more.sav
 
 echo Running multi test ...
-../bin/lowkey multi.k > multi.out
+KEYPATH=../lib ../bin/lowkey multi.k > multi.out
 diff multi.out multi.sav
 
 echo Running obj test ...
-../bin/lowkey obj.k > obj.out
+KEYPATH=../lib ../bin/lowkey obj.k > obj.out
 diff obj.out obj.sav
 
 echo Running ptr test ...
-../bin/lowkey ptr.k > ptr.out
+KEYPATH=../lib ../bin/lowkey ptr.k > ptr.out
 diff ptr.out ptr.sav
 


### PR DESCRIPTION
Haivng key/lowkey call checkkeylib on startup caused keytest.sh to generate different output.
Only show "Rebuild lib/keylib.k since xxx" message if -Debugkeylib is specified on command line.
Tweak code to strip off directory and separator in mdep_lsdir in both linux and stdio targets.
Call freeftime() at end of checkkeylibdir() to free any accumulated filenames so next call to checkkeylibdir starts with same conditions.
Set KEYPATH on lowkey invocations in keytest.sh to restrict the search to just ../lib - otherwise it treats all testcase code as part of keylib.