### PR TITLE
Add -Debugmemscribble to scribble over allocated memory before use

### DIFF
--- a/src/bltin.c
+++ b/src/bltin.c
@@ -1356,6 +1356,7 @@ bi_sbbyes(int argc)
 	long origtime;
 	Unchar* origbytes;
 	unsigned int origleng, newleng;
+	Unchar origport;
 
 	if ( argc != 2 && argc != 3 )
 		execerror("usage: subbytes(MIDIBYTES-phrase,start,length)");
@@ -1379,6 +1380,7 @@ bi_sbbyes(int argc)
 	origtime = timeof(n);
 	origbytes = ptrtobyte(n,0);
 	origleng = ntbytesleng(n);
+	origport = portof(n);
 
 	if ( argc >= 3 )
 		newleng = neednum(s,ARG(2));
@@ -1395,6 +1397,7 @@ bi_sbbyes(int argc)
 
 	n = newnt();
 	timeof(n) = origtime;
+	portof(n) = origport;
 	if ( newleng <= NOTE_DATA_NBYTES ) {
 		unsigned int i;
 		typeof(n) = NT_LE_NBYTES;

--- a/src/key.h
+++ b/src/key.h
@@ -1095,7 +1095,7 @@ extern Symlongp Numinst1, Numinst2, Kobjectoffset, Mousemoveevents;
 extern Symlongp Deftimeout;
 extern Symlongp Debuggesture, Debugstrsave;
 extern Symlongp Chancolors;
-extern Symlongp Debugkeylib;
+extern Symlongp Debugkeylib, Debugmemscribble;
 extern Phrasepp Currphr, Recphr;
 extern Symstrp Keypath, Musicpath, Keyroot, Initconfig, Keypagepersistent;
 extern Symstrp Printsep, Printend, Pathsep, Dirseparator, Devmidi, Machine;

--- a/src/keylib.c
+++ b/src/keylib.c
@@ -17,8 +17,15 @@
 #define errno_t int
 #endif
 
-long *Debugstrsave = NULL;
-long *Debugmalloc = NULL;
+typedef long *Symlongp;
+#define INIT_DEBUGARG_PAIR(name)		\
+	long Default##name = 0;			\
+	Symlongp name = &Default##name
+
+INIT_DEBUGARG_PAIR(Debugmemscribble);
+INIT_DEBUGARG_PAIR(Debugstrsave);
+INIT_DEBUGARG_PAIR(Debugmalloc);
+
 extern char *myfgets(char*, int, FILE*);
 
 /* Read all *.k file in the current directory and construct a keylib.k file */

--- a/src/misc.c
+++ b/src/misc.c
@@ -191,6 +191,9 @@ allocate(unsigned int s, char *tag)
 	}
 	if ( p == NULL )
 		allocerror();
+	if ( *Debugmemscribble ) {
+		memset(p, 0xa5, s);
+	}
 	return(p);
 }
 
@@ -239,7 +242,6 @@ dbgallocate(unsigned int s,char *tag)
 	char *p;
 	static int recurse = 0;
 
-
 	p = malloc(s);
 	recurse++;
 	{
@@ -248,6 +250,10 @@ dbgallocate(unsigned int s,char *tag)
 		}
 	}
 	recurse--;
+
+	if ( *Debugmemscribble ) {
+		memset(p, 0xa5, s);
+	}
 
 	m = (struct mminfo *)malloc(sizeof(struct mminfo));
 	m->ptr = p;

--- a/src/sym.c
+++ b/src/sym.c
@@ -59,6 +59,7 @@ INIT_DEBUGARG_PAIR(Debugkeylib);
 INIT_DEBUGARG_PAIR(Debugkill);
 INIT_DEBUGARG_PAIR(Debugkill1);
 INIT_DEBUGARG_PAIR(Debugmalloc);
+INIT_DEBUGARG_PAIR(Debugmemscribble);
 INIT_DEBUGARG_PAIR(Debugmidi);
 INIT_DEBUGARG_PAIR(Debugmouse);
 INIT_DEBUGARG_PAIR(Debugoff);
@@ -80,6 +81,7 @@ struct {
 	{ "Debugkill", &Debugkill, &DefaultDebugkill },
 	{ "Debugkill1", &Debugkill1, &DefaultDebugkill1 },
 	{ "Debugmalloc", &Debugmalloc, &DefaultDebugmalloc },
+	{ "Debugmemscribble", &Debugmemscribble, &DefaultDebugmemscribble },
 	{ "Debugmidi", &Debugmidi, &DefaultDebugmidi },
 	{ "Debugmouse", &Debugmouse, &DefaultDebugmouse },
 	{ "Debugoff", &Debugoff, &DefaultDebugoff },

--- a/tests/keytest.sh
+++ b/tests/keytest.sh
@@ -1,40 +1,46 @@
+#!/bin/sh
+
+ARGS="-Debugmemscribble"
+
+echo "Arg passed to lowkey: '${ARGS}'"
+
 echo Running ack test ...
-../bin/lowkey ack.k > ack.out
+../bin/lowkey $ARGS ack.k > ack.out
 diff ack.out ack.sav
 
 echo Running attrib test ...
-../bin/lowkey attrib.k > attrib.out
+../bin/lowkey $ARGS attrib.k > attrib.out
 diff attrib.out attrib.sav
 
 echo Running bigtest test ...
-../bin/lowkey bigtest.k > bigtest.out
+../bin/lowkey $ARGS bigtest.k > bigtest.out
 diff bigtest.out bigtest.sav
 
 echo Running control test ...
-../bin/lowkey control.k > control.out
+../bin/lowkey $ARGS control.k > control.out
 diff control.out control.sav
 
 echo Running dot test ...
-../bin/lowkey dot.k > dot.out
+../bin/lowkey $ARGS dot.k > dot.out
 diff dot.out dot.sav
 
 echo Running fork test ...
-../bin/lowkey fork.k > fork.out
+../bin/lowkey $ARGS fork.k > fork.out
 diff fork.out fork.sav
 
 echo Running more test ...
-../bin/lowkey more.k > more.out
+../bin/lowkey $ARGS more.k > more.out
 diff more.out more.sav
 
 echo Running multi test ...
-../bin/lowkey multi.k > multi.out
+../bin/lowkey $ARGS multi.k > multi.out
 diff multi.out multi.sav
 
 echo Running obj test ...
-../bin/lowkey obj.k > obj.out
+../bin/lowkey $ARGS obj.k > obj.out
 diff obj.out obj.sav
 
 echo Running ptr test ...
-../bin/lowkey ptr.k > ptr.out
+../bin/lowkey $ARGS ptr.k > ptr.out
 diff ptr.out ptr.sav
 


### PR DESCRIPTION
Modify dbg/allocate to scribble 0xa5 over allocated memory if newly added Debubmemscribble is set.
Modify bi_sbbyes to set the port of newly allocated not to be that of midibytes are cloned from.
Add INIT_DEBUGARG_PAIR macro to keylib.c and use to initialized Debugmemscribble, Debugstrsave and Debugmalloc variables. Modify keytest.sh to add "-Debugmemscribble" to each lowkey invocation(and announce what the common command line args are).