### PR TITLE
Change MIDI private1 type to intptr_t

### DIFF
--- a/mdep/linux/raw_midi.c
+++ b/mdep/linux/raw_midi.c
@@ -26,9 +26,9 @@ int
 mdep_initmidi(Midiport *inputs, Midiport *outputs)
 {
 	outputs[0].name = "alsa";
-	outputs[0].private1 = (int) NULL;
+	outputs[0].private1 = (intptr_t) NULL;
 	inputs[0].name = "alsa";
-	inputs[0].private1 = (int) NULL;
+	inputs[0].private1 = (intptr_t) NULL;
 
 	alsa_rawmidi_in.midihandle = NULL;
 	alsa_rawmidi_in.midifd = -1;
@@ -54,7 +54,7 @@ openmidiout(Midiport * port)
 		/*
 		 * It's already open.
 		 */
-		port->private1 = (int) a;
+		port->private1 = (intptr_t) a;
 		return 0;
 	}
 
@@ -87,7 +87,7 @@ openmidiout(Midiport * port)
 		fprintf(stderr,"Hey, midifd isn't muxable!\n");
 		exit(1);
 	}
-	port->private1 = (int) a;
+	port->private1 = (intptr_t) a;
 	
 	return(ret);
 }
@@ -106,7 +106,7 @@ openmidiin(Midiport * port)
 		/*
 		 * It's already open.
 		 */
-		port->private1 = (int) a;
+		port->private1 = (intptr_t) a;
 		return 0;
 	}
 
@@ -140,7 +140,7 @@ openmidiin(Midiport * port)
 		fprintf(stderr,"Hey, midifd isn't muxable!\n");
 		exit(1);
 	}
-	port->private1 = (int) a;
+	port->private1 = (intptr_t) a;
 
 	return(ret);
 }

--- a/mdep/raspbian/raw_midi.c
+++ b/mdep/raspbian/raw_midi.c
@@ -26,9 +26,9 @@ int
 mdep_initmidi(Midiport *inputs, Midiport *outputs)
 {
 	outputs[0].name = "alsa";
-	outputs[0].private1 = (int) NULL;
+	outputs[0].private1 = (intptr_t) NULL;
 	inputs[0].name = "alsa";
-	inputs[0].private1 = (int) NULL;
+	inputs[0].private1 = (intptr_t) NULL;
 
 	alsa_rawmidi_in.midihandle = NULL;
 	alsa_rawmidi_in.midifd = -1;
@@ -54,7 +54,7 @@ openmidiout(Midiport * port)
 		/*
 		 * It's already open.
 		 */
-		port->private1 = (int) a;
+		port->private1 = (intptr_t) a;
 		return 0;
 	}
 
@@ -87,7 +87,7 @@ openmidiout(Midiport * port)
 		fprintf(stderr,"Hey, midifd isn't muxable!\n");
 		exit(1);
 	}
-	port->private1 = (int) a;
+	port->private1 = (intptr_t) a;
 	
 	return(ret);
 }
@@ -106,7 +106,7 @@ openmidiin(Midiport * port)
 		/*
 		 * It's already open.
 		 */
-		port->private1 = (int) a;
+		port->private1 = (intptr_t) a;
 		return 0;
 	}
 
@@ -140,7 +140,7 @@ openmidiin(Midiport * port)
 		fprintf(stderr,"Hey, midifd isn't muxable!\n");
 		exit(1);
 	}
-	port->private1 = (int) a;
+	port->private1 = (intptr_t) a;
 
 	return(ret);
 }

--- a/src/key.h
+++ b/src/key.h
@@ -756,7 +756,7 @@ typedef struct Kobject {
 typedef struct Midiport {
 	int opened;
 	Symstr name;
-	int private1;	/* mdep layer can use this for whatever it wants */
+	intptr_t private1;	/* mdep layer can use this for whatever it wants */
 } Midiport;
 
 /*


### PR DESCRIPTION
Since some targets use Midiport private1 field as a pointer while other targets use it as an index, private1 needs to be an intptr_t type to make it large enough to suppress/fix "cast from pointer to integer of different size" warning/bug.