### PR TITLE
Add prev pointer to Instnode

### DIFF
--- a/src/code.c
+++ b/src/code.c
@@ -195,7 +195,12 @@ void
 rminstnode(Instnodep t,Instnodep prei,int adjust)
 {
 	Instnodep rmi = nextinode(prei);
-	nextinode(prei) = nextinode(rmi);
+	if ( nextinode(rmi) ) {
+		previnode(nextinode(rmi)) = previnode(rmi);
+	}
+	if ( previnode(rmi) ) {
+		nextinode(previnode(rmi)) = nextinode(rmi);
+	}
 	freeinode(rmi);
 	if ( adjust )
 		instnodepatch(t,rmi,nextinode(prei));
@@ -725,10 +730,13 @@ void
 addinode(Instnodep in)
 {
 	Instnodep last = Lastin[Niseg];
-	if ( last == NULL )
+	if ( last == NULL ) {
 		Iseg[Niseg] = in;
-	else
+	}
+	else {
 		nextinode(last) = in;
+		previnode(in) = last;
+	}
 	nextinode(in) = NULL;
 	Lastin[Niseg] = in;
 }
@@ -821,16 +829,8 @@ bltininst(BLTINCODE f)
 Instnodep
 previnstnode(register Instnodep ilow,register Instnodep in)
 {
-	register Instnodep nxt;
-
-	while ( ilow != NULL ) {
-		nxt = nextinode(ilow);
-		if ( nxt == in )
-			return(ilow);
-		ilow = nxt;
-	}
-	execerror("Can't find previnstnode!!");
-	return (Instnodep)NULL; /* NOTREACHED*/
+	dummyusage(ilow);
+	return previnode(in);
 }
 
 Instcode*

--- a/src/key.h
+++ b/src/key.h
@@ -533,7 +533,7 @@ typedef struct Instcode {
 
 typedef struct Instnode {
 	Instcode code;
-	Instnodep inext;
+	Instnodep iprev, inext;
 	int offset;	/* only used in inodes2code() */
 } Instnode;
 
@@ -951,6 +951,7 @@ extern Datum _Dnumtmp_;
 #define pushfunc_nochk(x) pushstk(x)
 
 #define setpc(i) Pc=(Unchar*)(i)
+#define previnode(in) ((in)->iprev)
 #define nextinode(in) ((in)->inext)
 
 #define SCAN_FUNCCODE(p) *(p)++

--- a/src/util.c
+++ b/src/util.c
@@ -1133,7 +1133,7 @@ newin(void)
 		used++;
 		i = lastin++;
 	}
-	i->inext = NULL;
+	i->iprev = i->inext = NULL;
 	i->code.type = 0;
 	return(i);
 }


### PR DESCRIPTION
Add iprev pointer to Instnode that points to the previous Instnode(or NULL) thereby creating a double-linked list of Instnodes which speeds up previnstnode().