### PR TITLE
Free bufflines content in k_reinittext()

### DIFF
--- a/src/kwind.c
+++ b/src/kwind.c
@@ -361,8 +361,12 @@ k_reinittext(Kwind *w)
 	w->currrow = 0;
 #endif
 
-	for ( pp=w->bufflines,n=w->numlines-1; n>=0 ; n-- )
+	for ( pp=w->bufflines,n=w->numlines-1; n>=0 ; n-- ) {
+		if ( *pp != w->currline ) {
+			kfree(*pp);
+		}
 		*pp++ = NULL;
+	}
 	w->currline[0] = '\0';
 	w->lastused = 0;
 	w->currlnum = 0;


### PR DESCRIPTION
Now that bufflines content is held temporarily9until overwritten), if a text window is reinitialized, instead of just resetting content of bufflines to null, need to kfree each entry - unless its the currline buffer.