### PR TITLE
Constants

### DIFF
--- a/doc/porting
+++ b/doc/porting
@@ -259,7 +259,17 @@ int mdep_mouse(int *ax,int *ay, int *am);
 
 	Get the current status of the mouse, putting the position into
 	*ax,*ay, and putting the current status of modifiers into *am.
-	Modifier values are: 1 for the control key, 2 for the shift key.
+	Modifier values are:
+		MOUSE_MOD_NONE: no modifier
+		MOUSE_MOD_CTRL: control key
+		MOUSE_MOD_SHIFT: shift key
+		MOUSE_MOD_CTRL_SHIFT: both control and shift key
+        Return values are:
+		MOUSE_BTN_NONE: no mouse button pushed
+                MOUSE_BTN_LEFT: left mouse button pushed
+                MOUSE_BTN_RIGHT: right mouse button pushed
+                MOUSE_BTN_MIDDLE: middle mouse button pushed
+	Note: Not all machines support middle mouse button...
 
 int mdep_mousewarp(int x, int y);
 

--- a/mdep/linux/mdep2.c
+++ b/mdep/linux/mdep2.c
@@ -284,13 +284,18 @@ updatedrect(XEvent ev)
 static int
 state2modifier(int s)
 {
-	int m;
-	if ( s & ShiftMask )
-		m = 2;
-	else if ( s & ControlMask )
-		m = 1;
-	else
-		m = 0;
+	int m = MOUSE_MOD_NONE;
+
+	if ( s & ControlMask ) {
+		if ( s & ShiftMask ) {
+			m = MOUSE_MOD_CTRL_SHIFT;
+		} else {
+			m = MOUSE_MOD_CTRL;
+		}
+	}
+	else if ( s & ShiftMask ) {
+		m = MOUSE_MOD_SHIFT;
+	}
 	return(m);
 }
 

--- a/mdep/nt/mdep2.c
+++ b/mdep/nt/mdep2.c
@@ -930,21 +930,29 @@ keyerrfile("KEYUP lParam=0x%lx wParam=0x%lx\n",(long)lParam,(long)wParam);
 	case WM_RBUTTONDOWN:
 		if ( Ignoretillup )
 			return 0;
-		m = mod = 0;
+		m = MOUSE_BTN_NONE;
 		if ( wParam & MK_LBUTTON )
-			m |= 1;
+			m = MOUSE_BTN_LEFT;
 		else if ( (wParam & MK_RBUTTON) || (wParam & MK_MBUTTON) )
-			m |= 2;
-		if ( wParam & MK_CONTROL )
-			mod |= 1;
-		if ( wParam & MK_SHIFT )
-			mod |= 2;
+			m = MOUSE_BTN_RIGHT;
+		mod = MOUSE_MOD_NONE;
+		if ( wParam & MK_CONTROL ) {
+			if ( wParam & MK_SHIFT ) {
+				mod = MOUSE_MOD_CTRL_SHIFT;
+			} else {
+				mod = MOUSE_MOD_CTRL;
+			}
+		}
+		else if ( wParam & MK_SHIFT ) {
+			mod = MOUSE_MOD_SHIFT;
+		}
 		goto gotmouse;
 
 	case WM_LBUTTONUP:
 	case WM_MBUTTONUP:
 	case WM_RBUTTONUP:
-		m = mod = 0;
+		m = MOUSE_BTN_NONE;
+		mod = MOUSE_MOD_NONE;
 		if ( Ignoretillup ) {
 			Ignoretillup = 0;
 			return 0;
@@ -959,12 +967,14 @@ keyerrfile("KEYUP lParam=0x%lx wParam=0x%lx\n",(long)lParam,(long)wParam);
 			return 0;
 		SetCursor(Kcursor);
 		saveevent(K_MOUSE);
-		m = 0;
-		if ( wParam & MK_LBUTTON )
-			m |= 1;
-		else if ( (wParam & MK_RBUTTON) || (wParam & MK_MBUTTON) )
-			m |= 2;
-		savemouse(LOWORD(lParam),HIWORD(lParam),m,0);
+		m = MOUSE_BTN_NONE;
+		if ( wParam & MK_LBUTTON ) {
+			m = MOUSE_BTN_LEFT;
+		}
+		else if ( (wParam & MK_RBUTTON) || (wParam & MK_MBUTTON) ) {
+			m = MOUSE_BTN_RIGHT;
+		}
+		savemouse(LOWORD(lParam),HIWORD(lParam),m,MOUSE_MOD_NONE);
 		return 0;
 
 	case WM_ACTIVATE:

--- a/mdep/ntcons/mdep2.c
+++ b/mdep/ntcons/mdep2.c
@@ -270,8 +270,8 @@ mdep_mouse(int *ax,int *ay,int *am)
 {
 	*ax = 0;
 	*ay = 0;
-	*am = 0;
-	return 0;
+	*am = MOUSE_MOD_NONE;
+	return MOUSE_BTN_NONE;
 }
 
 int

--- a/mdep/ntshare/mdep2.c
+++ b/mdep/ntshare/mdep2.c
@@ -702,15 +702,24 @@ WndProc (HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 	case WM_RBUTTONDOWN:
 		if ( Ignoretillup )
 			return 0;
-		m = mod = 0;
-		if ( wParam & MK_LBUTTON )
-			m |= 1;
-		else if ( (wParam & MK_RBUTTON) || (wParam & MK_MBUTTON) )
-			m |= 2;
-		if ( wParam & MK_CONTROL )
-			mod |= 1;
-		if ( wParam & MK_SHIFT )
-			mod |= 2;
+		m = MOUSE_BTN_NONE;
+		if ( wParam & MK_LBUTTON ) {
+			m = MOUSE_BTN_LEFT;
+		}
+		else if ( (wParam & MK_RBUTTON) || (wParam & MK_MBUTTON) ) {
+			m = MOUSE_BTN_RIGHT;
+		}
+		mod = MOUSE_MOD_NONE;
+		if ( wParam & MK_CONTROL ) {
+			if ( wParam & MK_SHIFT ) {
+				mod = MOUSE_MOD_CTRL_SHIFT;
+			} else {
+				mod = MOUSE_MOD_CTRL;
+			}
+		}
+		else if ( wParam & MK_SHIFT ) {
+			mod = MOUSE_MOD_SHIFT;
+		}
 		goto gotmouse;
 
 	case WM_LBUTTONUP:

--- a/mdep/raspbian/mdep.h
+++ b/mdep/raspbian/mdep.h
@@ -15,9 +15,17 @@
 #endif
 #include <setjmp.h>
 #include <errno.h>
+#include <inttypes.h>
 
+#define KEY_PRIdPTR PRIdPTR
+#define KEY_PRIxPTR PRIxPTR
+#define KEY_PRIdPTR_TYPE uintptr_t
+#define KEY_PRIxPTR_TYPE uintptr_t
 
 #define MACHINE "raspbian"	/* default value of keykit's Machine variable */
+
+/* GCC function attribute indicating a function does not return */
+#define NO_RETURN_ATTRIBUTE __attribute__((__noreturn__))
 
 #define _unlink unlink
 

--- a/mdep/raspbian/mdep2.c
+++ b/mdep/raspbian/mdep2.c
@@ -284,13 +284,18 @@ updatedrect(XEvent ev)
 static int
 state2modifier(int s)
 {
-	int m;
-	if ( s & ShiftMask )
-		m = 2;
-	else if ( s & ControlMask )
-		m = 1;
-	else
-		m = 0;
+	int m = MOUSE_MOD_NONE;
+
+	if ( s & ControlMask ) {
+		if ( s & ShiftMask ) {
+			m = MOUSE_MOD_CTRL_SHIFT;
+		} else {
+			m = MOUSE_MOD_CTRL;
+		}
+	}
+	else if ( s & ShiftMask ) {
+		m = MOUSE_MOD_SHIFT;
+	}
 	return(m);
 }
 

--- a/mdep/raspbian/mdep2.c
+++ b/mdep/raspbian/mdep2.c
@@ -232,11 +232,13 @@ mdep_ignoreinterrupt(void)
 	(void) signal(SIGBUS, SIG_IGN);
 }
 
+#if OLDSTUFF
 static void
 millisleep(int n)
 {
 	usleep(1000*n);
 }
+#endif
 
 static int
 kbdchar(void)
@@ -590,7 +592,6 @@ void
 mdep_prerc(void)
 {
 	extern Symlongp Merge;
-	char *p;
 
 	*Merge = 1;
 	*Panraster = 0;
@@ -656,7 +657,7 @@ mdep_musicpath(void)
 		p = (char *) malloc((unsigned)(3*strlen(keyroot())+64));
 		sprintf(p,".%s%s/music",*Pathsep,keyroot());
 		str = uniqstr(p);
-		kfree(p);
+		free(p);
 	}
         return str;
 }
@@ -675,7 +676,7 @@ mdep_keypath(void)
                 sprintf(p,".%s%s/liblocal%s%s/lib",
                         *Pathsep,keyroot(),*Pathsep,keyroot());
                 path = uniqstr(p);
-                kfree(p);
+                free(p);
         }
         return path;
 }
@@ -683,8 +684,6 @@ mdep_keypath(void)
 int
 mdep_makepath(char *dirname, char *filename, char *result, int resultsize)
 {
-	char *p, *q;
-
 	if ( resultsize < (int)(strlen(dirname)+strlen(filename)+5) )
 		return 1;
 
@@ -721,6 +720,10 @@ mdep_browse(char *lbl, char *expr, int mustexist)
 {
 	/* NOTE: this isn't really used if NOBROWSESUPPORT is set in mdep.h. */
 	/* fill in someday, when there's a standard file selection dialog */
+
+	dummyusage(lbl);
+	dummyusage(expr);
+	dummyusage(mustexist);
 	return NULL;
 }
 
@@ -747,15 +750,6 @@ mdep_putconsole(char *s)
 {
 	fputs(s,stdout);
 	(void) fflush(stdout);
-}
-
-static void
-clearrect(int x0,int y0,int x1,int y1)
-{
- 	XSetFunction(dpy,gc,F_STORE);
- 	XSetForeground(dpy,gc,bgpix);
-	resetmode();
-	XFillRectangle(dpy, Disp.dr, gc, x0,y0, x1-x0,y1-y0);
 }
 
 static void
@@ -791,7 +785,6 @@ int
 mdep_waitfor(int tmout)
 {
 	int ret;
-	int iii;
 	fd_set readfds;
 	fd_set exceptfds;
 	struct timeval t;
@@ -883,8 +876,17 @@ mdep_waitfor(int tmout)
 			(*Intrfunc)();
 			return K_CONSOLE;
 		}
-		sprintf(Msg1,"poll/select failed in mdep_waitfor() errno=%d Readfds=0x%x MaxFdUsed=%d\n",errno,ReadFds,MaxFdUsed);
-		execerror(Msg1);
+        {
+            int fd;
+            unsigned int maskReadFds = 0;
+            for (fd = 0; fd < MaxFdUsed; fd++)
+            {
+                if (FD_ISSET(fd, &readfds))
+                    maskReadFds |= (1 << fd);
+            }
+            sprintf(Msg1,"poll/select failed in mdep_waitfor() errno=%d Readfds= 0x%x MaxFdUsed=%d\n",errno,maskReadFds,MaxFdUsed);
+            execerror(Msg1);
+        }
 	}
 
 	for ( m=Topport; m!=NULL; m=m->next ) {
@@ -1098,7 +1100,9 @@ initdisplay(int argc,char **argv)
 	XSizeHints sizehints;
 	XWMHints wmhints;
 	char *geom = 0;
+#if OLDSTUFF
 	long et;
+#endif
 	int flags;
 	unsigned int width, height;
 	int x, y;
@@ -1418,6 +1422,9 @@ mdep_fillellipse(int x0,int y0,int x1,int y1)
 void
 mdep_fillpolygon(int *xarr, int *yarr, int arrsize)
 {
+	dummyusage(xarr);
+	dummyusage(yarr);
+	dummyusage(arrsize);
 	tprint("fillpolygon not supported on linux.\n");
 }
 
@@ -1438,7 +1445,7 @@ bfree(Bitmap *b)
 {
 	if(b){
 		XFreePixmap(dpy, b->dr);
-		free((char *)b);
+		free(b);
 	}
 }
 
@@ -1603,15 +1610,15 @@ static struct cinfo {
 	int hotx, hoty;
 	Cursor curs;
 } Clist[] = {
-	M_ARROW, (char*)myarrow_bits, (char*)myarrow_mask_bits, 1,1, NOCURSOR,
-	M_CROSS, (char*)cross_bits, (char*)cross_bits, 8,8, NOCURSOR,
-	M_SWEEP, (char*)sweep_bits, (char*)sweep_bits, 0,0, NOCURSOR,
-	M_LEFTRIGHT,(char*)leftright_bits, (char*)leftright_bits, 0,0,NOCURSOR,
-	M_UPDOWN, (char*)updown_bits, (char*)updown_bits, 0,0, NOCURSOR,
-	M_ANYWHERE, (char*)anywhere_bits, (char*)anywhere_bits, 8,8, NOCURSOR,
-	M_BUSY, (char*)coffee_bits, (char*)coffee_bits, 0,0, NOCURSOR,
-	M_NOTHING, (char*)no_bits, (char*)no_bits, 0,0, NOCURSOR,
-	-1, (char*)NULL, (char*)NULL, 0,0, NOCURSOR
+	{ M_ARROW, (char*)myarrow_bits, (char*)myarrow_mask_bits, 1,1, NOCURSOR },
+	{ M_CROSS, (char*)cross_bits, (char*)cross_bits, 8,8, NOCURSOR },
+	{ M_SWEEP, (char*)sweep_bits, (char*)sweep_bits, 0,0, NOCURSOR },
+	{ M_LEFTRIGHT,(char*)leftright_bits, (char*)leftright_bits, 0,0,NOCURSOR },
+	{ M_UPDOWN, (char*)updown_bits, (char*)updown_bits, 0,0, NOCURSOR },
+	{ M_ANYWHERE, (char*)anywhere_bits, (char*)anywhere_bits, 8,8, NOCURSOR },
+	{ M_BUSY, (char*)coffee_bits, (char*)coffee_bits, 0,0, NOCURSOR },
+	{ M_NOTHING, (char*)no_bits, (char*)no_bits, 0,0, NOCURSOR },
+	{ -1, (char*)NULL, (char*)NULL, 0,0, NOCURSOR }
 };
 
 void
@@ -1798,7 +1805,6 @@ tcpip_listen(char *hostname, char *servname)
 	SOCKET sock;
 	char myname[80];
 	unsigned short port;
-	int r;
 
 	sock = socket( AF_INET, SOCK_STREAM, 0);
 	if (sock == INVALID_SOCKET) {
@@ -1825,7 +1831,8 @@ tcpip_listen(char *hostname, char *servname)
 	local_sin.sin_port = port;
 
 	if ( hostname != NULL ) {
-		strncpy(myname,hostname,sizeof(myname));
+		strncpy(myname,hostname,sizeof(myname)-1);
+        myname[sizeof(myname)-1] = '\0';
 	} else {
 		if ( gethostname(myname,sizeof(myname)) < 0 ) {
 			sockerror(sock,"gethostname() failed, errno=%d",errno);
@@ -1930,21 +1937,6 @@ tcpip_write(SOCKET sock,char *msg,int msgsize)
 		nwritten += r;
 	}
 	return nwritten;
-}
-
-static int
-tcpip_recv(SOCKET sock,char *buff, int buffsize)
-{
-	int r = recv(sock,buff,buffsize,0);
-	if ( r==0 )
-		return 0;	/* socket has closed, perhaps we should eof? */
-	if ( r == SOCKET_ERROR && errno == EWOULDBLOCK )
-		return 0;
-	if ( r == SOCKET_ERROR ) {
-		sockerror(sock,"tcpip_recv() failed");
-		return 0;
-	}
-	return r;
 }
 
 static int
@@ -2081,13 +2073,53 @@ mdep_openport(char *name, char *mode, char *type)
 Datum
 mdep_ctlport(PORTHANDLE m, char *cmd, char *arg)
 {
+	dummyusage(m);
+	dummyusage(cmd);
+	dummyusage(arg);
 	return(Noval);
 }
 
 Datum
 mdep_mdep(int argc)
 {
-	return(Noval);
+	char *args[3];
+	int n;
+	Datum d;
+
+	d = Nullval;
+	/*
+	 * Things past the first 3 args might be integers
+	 */
+	for ( n=0; n<3 && n<argc; n++ ) {
+		Datum dd = ARG(n);
+		if ( dd.type == D_STR ) {
+			args[n] = needstr("mdep",dd);
+		} else {
+			args[n] = "";
+		}
+	}
+	for ( ; n<3; n++ )
+		args[n] = "";
+
+	/* Only handle mdep("env"...) commands (for now) */
+	if ( strcmp(args[0],"env") == 0 ) {
+		if ( strcmp(args[1], "get")==0 ) {
+			char *s = getenv(args[2]);
+			if ( s != NULL ) {
+				d = strdatum(uniqstr(s));
+			} else {
+				d = strdatum(Nullstr);
+			}
+		} else {
+			execerror("mdep(\"env\",... ) doesn't recognize %s\n",args[1]);
+		}
+	}
+	else {
+		/* unrecognized command */
+		eprint("Error: unrecognized mdep argument - %s\n",args[0]);
+	}
+	
+	return d;
 }
 
 static void
@@ -2111,7 +2143,7 @@ static void
 doaccept(SOCKET sock)
 {
 	SOCKET newsock;
-	int acc_sin_len;
+	socklen_t acc_sin_len;
 	SOCKADDR_IN acc_sin;
 	PORTHANDLE m0, m1, mp;
 	char *name;
@@ -2160,14 +2192,10 @@ static void
 tcpip_checksock_accept(Myport *m)
 {
 	int soerr = 0;
-	int soleng = sizeof(int);
+	socklen_t soleng = sizeof(int);
 	Myport *m2;
 
 	if ( m->sockstate == SOCK_LISTENING ) {
-		SOCKADDR_IN sin;  /* accepted socket */
-		SOCKET s2;
-		int addrlen;
-
 		getsockopt(m->sock,SOL_SOCKET,SO_ERROR,&soerr,&soleng);
 		if ( soerr == ECONNREFUSED ) {
 			m->isopen = 0;
@@ -2191,7 +2219,7 @@ static void
 tcpip_checksock_connect(Myport *m)
 {
 	int soerr = 0;
-	int soleng = sizeof(int);
+	socklen_t soleng = sizeof(int);
 	Myport *m2;
 
 	if ( m->sockstate == SOCK_UNCONNECTED ) {
@@ -2241,10 +2269,9 @@ mdep_getportdata(PORTHANDLE *handle, char *buff, int buffsize, Datum *pd)
 {
 	Myport *m;
 	Myport *m2;
-	int r;
-	int soerr = 0;
-	int soleng = sizeof(int);
+	int r = 0;
 
+	dummyusage(pd);
 	for ( m=Topport; m!=NULL; m=m->next ) {
 
 		if ( m->rw != TYPE_READ && m->rw != TYPE_LISTEN )
@@ -2357,5 +2384,7 @@ mdep_closeport(PORTHANDLE m)
 int
 mdep_help(char *fname, char *keyword)
 {
+	dummyusage(fname);
+	dummyusage(keyword);
 	return(1);
 }

--- a/mdep/stdio/mdep2.c
+++ b/mdep/stdio/mdep2.c
@@ -259,8 +259,8 @@ mdep_mouse(int *ax,int *ay,int *am)
 {
 	*ax = 0;
 	*ay = 0;
-	*am = 0;
-	return 0;
+	*am = MOUSE_MOD_NONE;
+	return MOUSE_BTN_NONE;
 }
 
 int

--- a/src/grid.h
+++ b/src/grid.h
@@ -203,6 +203,18 @@ typedef struct Pbitmap Pbitmap;
 #define M_ANYWHERE 6
 #define M_BUSY 7
 
+/* Values returned from mdep_mouse() */
+#define MOUSE_BTN_NONE		0
+#define MOUSE_BTN_LEFT		1
+#define MOUSE_BTN_RIGHT		2
+#define MOUSE_BTN_MIDDLE	3
+
+/* Mouse modifier values returned through mdep_mouse */
+#define MOUSE_MOD_NONE		0
+#define MOUSE_MOD_CTRL		1
+#define MOUSE_MOD_SHIFT		2
+#define MOUSE_MOD_CTRL_SHIFT	3
+
 extern Symlongp Sweepquant;
 extern Symlongp Dragquant;
 extern Symlongp Bendrange, Bendoffset, Showtext, Showbar;

--- a/src/grid.h
+++ b/src/grid.h
@@ -140,12 +140,11 @@ typedef struct Pbitmap Pbitmap;
 #define WIND_TEXT 3
 #define WIND_MENU 4
 
-/* These must match the macro values MENU_* in sym.c */
-#define M_NOCHOICE -1
-#define M_BACKUP -2
-#define M_UNDEFINED -3
-#define M_MOVE -4
-#define M_DELETE -5
+#define MENU_NOCHOICE -1
+#define MENU_BACKUP -2
+#define MENU_UNDEFINED -3
+#define MENU_MOVE -4
+#define MENU_DELETE -5
 
 /* style() method values */
 #define MSTYLE_NOBORDER		0

--- a/src/kwind.c
+++ b/src/kwind.c
@@ -809,7 +809,7 @@ k_initmenu(Kwind *w)
 	w->km.menusize = *Menusize;
 	w->km.made = 0;
 	w->km.top = 0;
-	w->km.choice = M_NOCHOICE;
+	w->km.choice = MENU_NOCHOICE;
 	w->km.width = 0;
 	w->km.header = 8;
 }

--- a/src/menu.c
+++ b/src/menu.c
@@ -159,7 +159,7 @@ menusetsize(Kwind *w, int x0, int y0, int x1, int y1)
 		sz = 2;
 	w->km.menusize = sz;
 	w->km.top = 0;
-	w->km.choice = M_NOCHOICE;
+	w->km.choice = MENU_NOCHOICE;
 	w->lasty = y0;
 }
 
@@ -272,14 +272,14 @@ updatemenu(Kwind *w,int mx,int my, int nodraw)
 		if ( w->km.choice >= 0 ) {
 			unhighchoice(w);
 		}
-		w->km.choice = M_NOCHOICE;
+		w->km.choice = MENU_NOCHOICE;
 		return;
 	}
 
 	/* see if we're in a menu item */
 	nchoice = menuchoice(w,mx,my);
 
-	if ( nchoice != M_MOVE && nchoice != M_DELETE ) {
+	if ( nchoice != MENU_MOVE && nchoice != MENU_DELETE ) {
 		/* see if we're in the scroll bar */
 		if ( scrollupdate(w,mx,my) )
 			return;
@@ -290,7 +290,7 @@ updatemenu(Kwind *w,int mx,int my, int nodraw)
 
 		/* Normally, unhighlight the item we've left */
 		unhighchoice(w);
-		w->km.choice = M_NOCHOICE;
+		w->km.choice = MENU_NOCHOICE;
 	}
 
 	/* highlight the new choice */
@@ -318,7 +318,7 @@ scrollupdate(Kwind *w,int mx,int my)
 	/* if we just moved into the scrol bar... */
 	if ( w->km.choice >= 0 ) {
 		highchoice(w);
-		w->km.choice = M_NOCHOICE;
+		w->km.choice = MENU_NOCHOICE;
 	}
 	w->inscroll = 1;
 
@@ -360,16 +360,16 @@ menuchoice(Kwind *w,int x,int y)
 	int n;
 	int ny = w->km.y + w->km.header;
 	int nshow = shown(w);
-	int nchoice = M_NOCHOICE;
+	int nchoice = MENU_NOCHOICE;
 	int x0 = w->km.x;
 	int x1 = x0 + w->km.width;
 
 	if ( x >= x0 && x <= x1 ) {
 		if ( y > w->km.y && y < ny ) {
 			if ( x > ((x0+x1)/2+x1)/2 )
-				nchoice = M_DELETE;
+				nchoice = MENU_DELETE;
 			else
-				nchoice = M_MOVE;
+				nchoice = MENU_MOVE;
 		}
 		else for ( n=0; n<nshow; ny+=Menuysize,n++ ) {
 			if ( y > ny && y <= (ny+Menuysize) ) {

--- a/src/sym.c
+++ b/src/sym.c
@@ -1054,11 +1054,11 @@ static struct Macrointeger Stdintegermacros[] = {
 	/* { "CUT_PITCH",	CUT_PITCH }, - add for completeness??? */
 
 	/* values for menudo() */
-	{ "MENU_NOCHOICE",	M_NOCHOICE },
-	{ "MENU_BACKUP",	M_BACKUP },
-	{ "MENU_UNDEFINED",	M_UNDEFINED },
-	{ "MENU_MOVE",		M_MOVE },
-	{ "MENU_DELETE",	M_DELETE },
+	{ "MENU_NOCHOICE",	MENU_NOCHOICE },
+	{ "MENU_BACKUP",	MENU_BACKUP },
+	{ "MENU_UNDEFINED",	MENU_UNDEFINED },
+	{ "MENU_MOVE",		MENU_MOVE },
+	{ "MENU_DELETE",	MENU_DELETE },
 	
 	/* values for draw() methods */
 	{ "CLEAR",		P_CLEAR },

--- a/src/sym.c
+++ b/src/sym.c
@@ -1059,7 +1059,18 @@ static struct Macrointeger Stdintegermacros[] = {
 	{ "MENU_UNDEFINED",	MENU_UNDEFINED },
 	{ "MENU_MOVE",		MENU_MOVE },
 	{ "MENU_DELETE",	MENU_DELETE },
-	
+
+	/* mouse button values */
+	{ "MOUSE_BTN_NONE",	MOUSE_BTN_NONE },
+	{ "MOUSE_BTN_LEFT",	MOUSE_BTN_LEFT },
+	{ "MOUSE_BTN_RIGHT",	MOUSE_BTN_RIGHT },
+
+	/* mouse modifier values */
+	{ "MOUSE_MOD_NONE",	MOUSE_MOD_NONE },
+	{ "MOUSE_MOD_CTRL",	MOUSE_MOD_CTRL },
+	{ "MOUSE_MOD_SHIFT",	MOUSE_MOD_SHIFT },
+	{ "MOUSE_MOD_CTRL_SHIFT", MOUSE_MOD_CTRL_SHIFT },
+
 	/* values for draw() methods */
 	{ "CLEAR",		P_CLEAR },
 	{ "STORE",		P_STORE },


### PR DESCRIPTION
Update raspbian mdep to match linux mdep.
Add mouse_btn_xxx and mouse_mod_xxx constants.
Rework mdep_mouse implementaitons to return control+shift mouse modifier.
Rename M_xxx to MENU_xxx constants for menus to be more consistent with keykit code constants.
Fix checkmouse to remap unknown mouse buttons to right mouse button(previous check allowed middle button).