### PR TITLE
Coalese multiple arrays together into array of structures

### DIFF
--- a/src/key.h
+++ b/src/key.h
@@ -1024,6 +1024,7 @@ extern long Msg1size, Msg2size, Msg3size;
 extern unsigned int Buffsize;
 extern int yydebug;
 extern FILE *Fin, *Fout;
+extern int sContextIdx;
 extern Datum Zeroval, Noval, Nullval;
 extern Datum Str_x0, Str_y0, Str_x1, Str_y1, Str_x, Str_y, Str_button;
 extern Datum Str_type, Str_mouse, Str_down, Str_up, Str_drag, Str_move;

--- a/src/task.c
+++ b/src/task.c
@@ -613,8 +613,15 @@ exectasks(int nosetjmp)
 	// KeyPyState = PyEval_SaveThread();
 #endif
 
-	if ( (!nosetjmp) )
-		setjmp(Begin);
+	if ( (!nosetjmp) ) {
+		int saveContextLevel = sContextIdx;
+		int ret;
+		ret = setjmp(Begin);
+		if ( ret != 0 ) {
+			popscontextuntil(saveContextLevel);
+		}
+	}
+		
 
 	setintcatch();
 


### PR DESCRIPTION
In keykit, there are two areas where multiple arrays are used to track data in lockstep - instruction segments (Iseg, Lastin, Future) and nested source context (Fin, Infile, Lineno, Autopop). Replace all those arrays with two arrays of structures, InstSegment that holds Iseg, Lastin, Future, and SourceContext that holds Fin, Infile Lineo and Autopop.
When execerror is called, need to "unwind" SourceContext back to what was in effect when execstack was called - add popscontextuntil(level) that pops source context until the saved level matchs the current level - allowing following calls to pushfin to succeed.