### PR TITLE
Track color of each character in a text window

### DIFF
--- a/src/grid.h
+++ b/src/grid.h
@@ -49,6 +49,12 @@ struct Kmenu {
 			/* more than this enables a scrollbar. */
 };
 
+struct TextColor {
+	char *text;
+	ubyte *color;
+};
+typedef struct TextColor TextColor;
+
 struct Kwind {
 	int wnum;
 	int type;	/* WIND_* */
@@ -72,14 +78,14 @@ struct Kwind {
 	int currx, curry;	/* Coordinates of currrow,currcol */
 	int currcols;		/* Number of cols shown */
 	int disprows;		/* Number of rows shown */
-	char **bufflines;	/* Circular buffer of saved lines.  The */
+	TextColor *bufflines;	/* Circular buffer of saved lines.  The */
 				/* direction is reversed from what you might */
 				/* think.  If toplnum is 50 (i.e. the 1st */
 				/* line on the display is bufflines[50]), */
 				/* then the 2nd display line is bufflines[49]*/
 	int numlines;		/* Total number of lines in bufflines */
 	int nactive;		/* Number active lines in bufflines */
-	char *currline;		/* active line */
+	TextColor currline;	/* active line */
 	int currlinelen;        /* size of currline */
 	int currlnum;		/* index of that line in bufflines */
 	int toplnum;		/* index (in bufflines) of top row in display*/

--- a/src/key.h
+++ b/src/key.h
@@ -42,6 +42,8 @@
 #include "Python.h"
 #endif
 
+typedef unsigned char ubyte; /* Unsigned byte */
+
 #ifndef INT16
 #define INT16 short
 #endif

--- a/src/kwind.c
+++ b/src/kwind.c
@@ -315,7 +315,6 @@ void
 k_inittext(Kwind *w)
 {
 	int n;
-	char **pp;
 
 	w->inscroll = 0;
 	w->currcols = 0;
@@ -328,13 +327,17 @@ k_inittext(Kwind *w)
 #define MAXCOLS (2+(Wroot->x1/mdep_fontwidth()))
 
 	w->numlines = *Textscrollsize;
-	w->bufflines = (char **) kmalloc(w->numlines*sizeof(char *),"inittext");
-	for ( pp=w->bufflines,n=w->numlines-1; n>=0 ; n-- )
-		*pp++ = NULL;
+	w->bufflines = (TextColor *)kmalloc(w->numlines*sizeof(TextColor),"inittext");
+	for ( n=0;n<w->numlines;++n ) {
+		TextColor *pp = &w->bufflines[n];
+		pp->text = NULL;
+		pp->color = NULL;
+	}
 	w->currlinelen = MAXCOLS;
-	w->currline = kmalloc(w->currlinelen,"inittext");
+	w->currline.text = kmalloc(w->currlinelen*sizeof(char),"inittext");
+	w->currline.color = kmalloc(w->currlinelen*sizeof(ubyte),"inittext");
 
-	w->currline[0] = '\0';
+	w->currline.text[0] = '\0';
 	w->lastused = 0;
 	w->currlnum = 0;
 	w->bufflines[w->currlnum] = w->currline;
@@ -350,15 +353,22 @@ k_reinittext(Kwind *w)
 	/* Free all entries in bufflines - except if its currline.
 	 * Set all entries in bufflines to NULL. */
 	for ( idx=0; idx<w->numlines; ++idx ) {
-		if ( w->bufflines[idx] != NULL ) {
-			if ( w->bufflines[idx] != w->currline ) {
-				kfree(w->bufflines[idx]);
+		TextColor *pp = &w->bufflines[idx];
+		if ( pp->text != NULL ) {
+			if ( pp->text != w->currline.text ) {
+				kfree(pp->text);
 			}
-			w->bufflines[idx] = NULL;
+			pp->text = NULL;
+		}
+		if ( pp->color != NULL ) {
+			if ( pp->color != w->currline.color ) {
+				kfree(pp->color);
+			}
+			pp->color = NULL;
 		}
 	}
 
-	w->currline[0] = '\0';
+	w->currline.text[0] = '\0';
 	w->lastused = 0;
 	w->currlnum = 0;
 	w->bufflines[w->currlnum] = w->currline;


### PR DESCRIPTION
execution of "colormix(10,0,65535,0);colorset(10); printf("Boo!");colorset(1)" causes the text to come out in green(along iwth the prompt), but redrawing the screen causes "Boo!" to be displayed in black(and restores the prompt to black). To fix losing specified text color requires extending concept of bufflines to track not only the text, but also the color of each character and in redrawtext() group together (up to CHARS_IN_CHUNK)chars of same color and draw them.